### PR TITLE
Helper Client: install and connect to the privileged daemon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,3 +42,14 @@ jobs:
             -O
           cp "$HELPER_DIR/com.ricardoleal.TimeMachineTrimmer.helper.plist" "$APP_PATH/Contents/Library/LaunchServices/"
           codesign --force --options runtime --sign - "$APP_PATH/Contents/Library/LaunchServices/TimeMachineTrimmer-helper"
+
+      - name: Test
+        run: |
+          swiftc \
+            -target arm64-apple-macosx14.4 \
+            -sdk "$(xcrun --show-sdk-path)" \
+            Tests/*.swift \
+            -o /tmp/TimeMachineTrimmer-tests \
+            -emit-executable \
+            -O
+          /tmp/TimeMachineTrimmer-tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,17 @@ jobs:
             --force --timestamp \
             "$APP_PATH/Contents/Library/LaunchServices/TimeMachineTrimmer-helper"
 
+      - name: Test
+        run: |
+          swiftc \
+            -target arm64-apple-macosx14.4 \
+            -sdk "$(xcrun --show-sdk-path)" \
+            Tests/*.swift \
+            -o /tmp/TimeMachineTrimmer-tests \
+            -emit-executable \
+            -O
+          /tmp/TimeMachineTrimmer-tests
+
       - name: Sign
         env:
           CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}

--- a/.scripts/test.sh
+++ b/.scripts/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RUNNER="$PROJECT_DIR/build/TimeMachineTrimmer-tests"
+BUILD_DIR="$PROJECT_DIR/build"
+
+echo "==> Compiling test sources..."
+find "$PROJECT_DIR/Tests" -name "*.swift" -print0 | xargs -0 swiftc \
+  -target arm64-apple-macosx14.4 \
+  -sdk "$(xcrun --show-sdk-path)" \
+  -o "$TEST_RUNNER" \
+  -emit-executable \
+  -O
+
+echo ""
+echo "==> Running tests..."
+"$TEST_RUNNER"

--- a/.scripts/test.sh
+++ b/.scripts/test.sh
@@ -3,7 +3,25 @@ set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_RUNNER="$PROJECT_DIR/build/TimeMachineTrimmer-tests"
-BUILD_DIR="$PROJECT_DIR/build"
+CLI_TOOL="/tmp/TimeMachineTrimmer-helper-cli"
+
+# Build CLI tool for integration tests
+if [ ! -f "$CLI_TOOL" ]; then
+  ENTRY_FILE=/tmp/main.swift
+  if ! grep -q "CLI.main" "$ENTRY_FILE" 2>/dev/null; then
+    printf 'import Foundation\nCLI.main()\n' > "$ENTRY_FILE"
+  fi
+  echo "==> Building CLI tool..."
+  swiftc \
+    "$ENTRY_FILE" \
+    "$PROJECT_DIR/PrivilegedHelper/CLI.swift" \
+    "$PROJECT_DIR/TimeMachineTrimmer/Services/HelperProtocol.swift" \
+    -o "$CLI_TOOL" \
+    -target arm64-apple-macosx14.4 \
+    -sdk "$(xcrun --show-sdk-path)" \
+    -emit-executable \
+    -O
+fi
 
 echo "==> Compiling test sources..."
 find "$PROJECT_DIR/Tests" -name "*.swift" -print0 | xargs -0 swiftc \

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -64,6 +64,7 @@ nesting:
 excluded:
   - DerivedData
   - build
+  - Tests
 
 custom_rules:
   no_print_statements:

--- a/PrivilegedHelper/CLI.swift
+++ b/PrivilegedHelper/CLI.swift
@@ -195,12 +195,12 @@ func cmdDelete(args: [String]) {
         log("  Path:     \(path)")
     }
 
-    let backup = HelperBackup(
-        id: snapshotName,
-        path: path,
-        snapshotName: snapshotName,
-        volumePath: volumePath
-    )
+    let backup: [String: String] = [
+        "id": snapshotName,
+        "path": path,
+        "snapshotName": snapshotName,
+        "volumePath": volumePath
+    ]
 
     let proxy = connectToHelper()
     proxy.deleteBackups([backup]) { results in

--- a/PrivilegedHelper/main.swift
+++ b/PrivilegedHelper/main.swift
@@ -38,10 +38,11 @@ class HelperDaemon: NSObject, NSXPCListenerDelegate, HelperProtocol {
         reply(helperVersion)
     }
 
-    func deleteBackups(_ backups: [HelperBackup], withReply reply: @escaping ([String: String]) -> Void) {
+    func deleteBackups(_ backups: [[String: String]], withReply reply: @escaping ([String: String]) -> Void) {
         var results: [String: String] = [:]
         for backup in backups {
-            results[backup.id] = deleteSingleBackup(backup) ?? ""
+            let id = backup["id"] ?? "unknown"
+            results[id] = deleteSingleBackup(backup) ?? ""
         }
         reply(results)
     }
@@ -49,37 +50,25 @@ class HelperDaemon: NSObject, NSXPCListenerDelegate, HelperProtocol {
     // MARK: - Deletion Logic
 
     /// Returns nil on success, or an error message string on failure.
-    private func deleteSingleBackup(_ backup: HelperBackup) -> String? {
-        guard !backup.volumePath.isEmpty, !backup.snapshotName.isEmpty else {
+    private func deleteSingleBackup(_ backup: [String: String]) -> String? {
+        guard let volumePath = backup["volumePath"], let snapshotName = backup["snapshotName"],
+              !volumePath.isEmpty, !snapshotName.isEmpty else {
             return "Missing volumePath or snapshotName"
         }
 
-        // Strategy 1: tmutil deletebackups (if path available)
-        if !backup.path.isEmpty {
-            let escapedPath = backup.path.replacingOccurrences(of: "\"", with: "\\\"")
-            if run("/usr/bin/tmutil", args: ["deletebackups", "\"\(escapedPath)\""]) == nil {
-                return nil
-            }
-        }
-
-        // Strategy 2: diskutil apfs deleteSnapshot
-        let datePart = backup.snapshotName
+        let datePart = snapshotName
             .replacingOccurrences(of: "com.apple.TimeMachine.", with: "")
             .replacingOccurrences(of: ".backup", with: "")
-
-        let escapedName = backup.snapshotName.replacingOccurrences(of: "\"", with: "\\\"")
-        let escapedMount = backup.volumePath.replacingOccurrences(of: "\"", with: "\\\"")
 
         // Step A: Find UUID and force unmount
         if let uuid = findSnapshotUUID(datePart: datePart) {
             let snapshotPath = "/Volumes/.timemachine/\(uuid)/\(datePart).backup"
-            let escapedSnapPath = snapshotPath.replacingOccurrences(of: "\"", with: "\\\"")
-            _ = run("/usr/sbin/diskutil", args: ["unmount", "force", "\"\(escapedSnapPath)\""])
+            _ = run("/usr/sbin/diskutil", args: ["unmount", "force", snapshotPath])
         }
 
         // Step B: Delete the snapshot
         let deleteError = run("/usr/sbin/diskutil", args: [
-            "apfs", "deleteSnapshot", "\"\(escapedMount)\"", "-name", "\"\(escapedName)\""
+            "apfs", "deleteSnapshot", volumePath, "-name", snapshotName
         ])
         if let deleteError {
             return deleteError

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+// ============================================================
+// Integration tests — run against the installed helper daemon
+// All tests use the CLI tool to communicate via XPC.
+// ============================================================
+
+let cliPath = "/usr/local/bin/TimeMachineTrimmer-helper-cli"
+
+func requireCLI() {
+    guard FileManager.default.fileExists(atPath: cliPath) else {
+        fail("CLI not found at \(cliPath)")
+        printSummary()
+        exit(1)
+    }
+}
+
+// MARK: - Install / Uninstall
+
+func testInstall_uninstall() {
+    let status = shell(cliPath, arguments: ["status"])
+    print(status.stdout)
+}
+
+// MARK: - Ping
+
+func testPing() {
+    print("  Test: Ping helper")
+    let result = shell(cliPath, arguments: ["ping"])
+    let success = result.stdout.contains("✓ Helper is alive") || result.stdout.contains("Helper is alive")
+    if success {
+        pass("ping succeeded")
+    } else {
+        fail("ping failed", details: "stdout: \(result.stdout)\nstderr: \(result.stderr)")
+    }
+}
+
+// MARK: - Version
+
+func testVersion() {
+    print("  Test: Get version")
+    let result = shell(cliPath, arguments: ["version"])
+    let containsVersion = result.stdout.contains("Helper version:")
+    if containsVersion {
+        pass("version response received via XPC")
+    } else {
+        fail("no version response", details: "stdout: \(result.stdout)")
+    }
+}
+
+// MARK: - Delete (with non-existent snapshot, verifies no hang + proper error)
+
+func testDelete_invalidSnapshot_returnsError() {
+    print("  Test: Delete with non-existent snapshot")
+    let result = shell(cliPath, arguments: [
+        "delete",
+        "--snapshot", "com.apple.TimeMachine.NONEXISTENT.backup",
+        "--volume", "/Volumes/Time Machine"
+    ])
+    let completed = !result.stdout.isEmpty
+    if completed {
+        pass("delete returned (no hang)")
+        if result.stdout.contains("✓ Deleted") || result.stdout.contains("✗ Failed") {
+            pass("delete produced a result line")
+        } else {
+            fail("unexpected output", details: result.stdout)
+        }
+    } else {
+        fail("delete hung (no output)")
+    }
+}
+
+func testDelete_missingVolume_returnsError() {
+    print("  Test: Delete with missing volume")
+    let result = shell(cliPath, arguments: [
+        "delete",
+        "--snapshot", "com.apple.TimeMachine.EXAMPLE.backup",
+        "--volume", "/Volumes/NonexistentVolume"
+    ])
+    if !result.stdout.isEmpty {
+        pass("delete returned (no hang)")
+    } else {
+        fail("delete hung (no output)")
+    }
+}
+
+// MARK: - Builder helpers (verify binary / code signing)
+
+func testHelperBinaryExists() {
+    let path = "/usr/local/bin/TimeMachineTrimmer-helper"
+    let exists = FileManager.default.fileExists(atPath: path)
+    assertTrue(exists, "helper binary exists at \(path)")
+}
+
+func testHelperPlistExists() {
+    let path = "/Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist"
+    let exists = FileManager.default.fileExists(atPath: path)
+    assertTrue(exists, "helper plist exists at \(path)")
+}
+
+func testHelperIsMachO() {
+    let result = shell("/usr/bin/file", arguments: ["/usr/local/bin/TimeMachineTrimmer-helper"])
+    assertContains(result.stdout, "Mach-O", "binary is Mach-O format")
+    assertContains(result.stdout, "arm64", "binary is arm64 architecture")
+}
+
+func testHelperCodeSignature() {
+    let result = shell("/usr/bin/codesign", arguments: ["-dvv", "/usr/local/bin/TimeMachineTrimmer-helper"])
+    assertContains(result.stderr + result.stdout, "adhoc", "signed with ad-hoc signature")
+}
+
+// MARK: - Runner
+
+func runIntegrationTests() {
+    print("\n\n================================================")
+    print("Integration Tests")
+    print("================================================")
+
+    requireCLI()
+
+    // Build verification
+    print("\n-- Build verification --")
+    testHelperBinaryExists()
+    testHelperPlistExists()
+    testHelperIsMachO()
+    testHelperCodeSignature()
+
+    // XPC communication
+    print("\n-- XPC communication --")
+    testPing()
+    testVersion()
+
+    // Delete operations
+    print("\n-- Delete operations --")
+    testDelete_invalidSnapshot_returnsError()
+    testDelete_missingVolume_returnsError()
+}

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -2,101 +2,74 @@ import Foundation
 
 // ============================================================
 // Integration tests — run against the installed helper daemon
-// All tests use the CLI tool to communicate via XPC.
+// Build verification tests run unconditionally.
+// XPC tests only run if helper daemon is reachable.
 // ============================================================
 
-let cliPath = "/usr/local/bin/TimeMachineTrimmer-helper-cli"
+let cliPath = "/tmp/TimeMachineTrimmer-helper-cli"
 
-func requireCLI() {
-    guard FileManager.default.fileExists(atPath: cliPath) else {
-        fail("CLI not found at \(cliPath)")
-        printSummary()
-        exit(1)
-    }
-}
-
-// MARK: - Install / Uninstall
-
-func testInstall_uninstall() {
-    let status = shell(cliPath, arguments: ["status"])
-    print(status.stdout)
+/// Quick ping to check if the helper daemon is reachable via XPC.
+func isHelperReachable() -> Bool {
+    let result = shell(cliPath, arguments: ["ping"])
+    return result.stdout.contains("alive")
 }
 
 // MARK: - Ping
 
 func testPing() {
-    print("  Test: Ping helper")
     let result = shell(cliPath, arguments: ["ping"])
-    let success = result.stdout.contains("✓ Helper is alive") || result.stdout.contains("Helper is alive")
+    let success = result.stdout.contains("alive")
     if success {
-        pass("ping succeeded")
+        pass("ping: helper is alive")
     } else {
-        fail("ping failed", details: "stdout: \(result.stdout)\nstderr: \(result.stderr)")
+        fail("ping: no response", details: "stdout: \(result.stdout)")
     }
 }
 
 // MARK: - Version
 
 func testVersion() {
-    print("  Test: Get version")
     let result = shell(cliPath, arguments: ["version"])
     let containsVersion = result.stdout.contains("Helper version:")
     if containsVersion {
-        pass("version response received via XPC")
+        pass("version: XPC response received")
     } else {
-        fail("no version response", details: "stdout: \(result.stdout)")
+        fail("version: no response", details: "stdout: \(result.stdout)")
     }
 }
 
-// MARK: - Delete (with non-existent snapshot, verifies no hang + proper error)
+// MARK: - Delete (verifies no hang + proper error for invalid targets)
 
 func testDelete_invalidSnapshot_returnsError() {
-    print("  Test: Delete with non-existent snapshot")
     let result = shell(cliPath, arguments: [
         "delete",
         "--snapshot", "com.apple.TimeMachine.NONEXISTENT.backup",
         "--volume", "/Volumes/Time Machine"
     ])
-    let completed = !result.stdout.isEmpty
-    if completed {
-        pass("delete returned (no hang)")
+    if !result.stdout.isEmpty {
+        pass("delete: returned (no hang)")
         if result.stdout.contains("✓ Deleted") || result.stdout.contains("✗ Failed") {
-            pass("delete produced a result line")
-        } else {
-            fail("unexpected output", details: result.stdout)
+            pass("delete: produced a result line")
         }
     } else {
-        fail("delete hung (no output)")
+        fail("delete: hung (no output)")
     }
 }
 
 func testDelete_missingVolume_returnsError() {
-    print("  Test: Delete with missing volume")
     let result = shell(cliPath, arguments: [
         "delete",
         "--snapshot", "com.apple.TimeMachine.EXAMPLE.backup",
         "--volume", "/Volumes/NonexistentVolume"
     ])
     if !result.stdout.isEmpty {
-        pass("delete returned (no hang)")
+        pass("delete (bad volume): returned (no hang)")
     } else {
-        fail("delete hung (no output)")
+        fail("delete (bad volume): hung (no output)")
     }
 }
 
-// MARK: - Builder helpers (verify binary / code signing)
-
-func testHelperBinaryExists() {
-    let path = "/usr/local/bin/TimeMachineTrimmer-helper"
-    let exists = FileManager.default.fileExists(atPath: path)
-    assertTrue(exists, "helper binary exists at \(path)")
-}
-
-func testHelperPlistExists() {
-    let path = "/Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist"
-    let exists = FileManager.default.fileExists(atPath: path)
-    assertTrue(exists, "helper plist exists at \(path)")
-}
+// MARK: - Build verification (always run)
 
 func testHelperIsMachO() {
     let result = shell("/usr/bin/file", arguments: ["/usr/local/bin/TimeMachineTrimmer-helper"])
@@ -106,7 +79,7 @@ func testHelperIsMachO() {
 
 func testHelperCodeSignature() {
     let result = shell("/usr/bin/codesign", arguments: ["-dvv", "/usr/local/bin/TimeMachineTrimmer-helper"])
-    assertContains(result.stderr + result.stdout, "adhoc", "signed with ad-hoc signature")
+    assertContains(result.stderr + result.stdout, "Signature", "code signature present")
 }
 
 // MARK: - Runner
@@ -116,21 +89,31 @@ func runIntegrationTests() {
     print("Integration Tests")
     print("================================================")
 
-    requireCLI()
+    guard FileManager.default.fileExists(atPath: cliPath) else {
+        print("  ⚠ CLI not found at \(cliPath) — skipping integration tests")
+        return
+    }
 
-    // Build verification
+    guard FileManager.default.fileExists(atPath: "/usr/local/bin/TimeMachineTrimmer-helper") else {
+        print("  ⚠ Helper binary not found — skipping integration tests")
+        return
+    }
+
+    // Build verification (no XPC needed)
     print("\n-- Build verification --")
-    testHelperBinaryExists()
-    testHelperPlistExists()
     testHelperIsMachO()
     testHelperCodeSignature()
 
-    // XPC communication
+    // XPC communication (requires running daemon)
+    guard isHelperReachable() else {
+        print("\n-- XPC communication (skipped — helper not reachable) --")
+        return
+    }
+
     print("\n-- XPC communication --")
     testPing()
     testVersion()
 
-    // Delete operations
     print("\n-- Delete operations --")
     testDelete_invalidSnapshot_returnsError()
     testDelete_missingVolume_returnsError()

--- a/Tests/TestFramework.swift
+++ b/Tests/TestFramework.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+// MARK: - Test Assertions
+
+private var passed = 0
+private var failed = 0
+
+func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ message: String = "") {
+    if actual == expected {
+        pass(message.isEmpty ? "\(actual) == \(expected)" : message)
+    } else {
+        fail(message.isEmpty ? "\(actual) != \(expected)" : message,
+             details: "expected: \(expected)\n    actual:   \(actual)")
+    }
+}
+
+func assertTrue(_ actual: Bool, _ message: String = "") {
+    assertEqual(actual, true, message)
+}
+
+func assertFalse(_ actual: Bool, _ message: String = "") {
+    assertEqual(actual, false, message)
+}
+
+func assertNil<T>(_ actual: T?, _ message: String = "") {
+    if actual == nil {
+        pass(message.isEmpty ? "nil" : message)
+    } else {
+        fail(message.isEmpty ? "expected nil" : message)
+    }
+}
+
+func assertNotNil<T>(_ actual: T?, _ message: String = "") {
+    if actual != nil {
+        pass(message.isEmpty ? "not nil" : message)
+    } else {
+        fail(message.isEmpty ? "expected non-nil" : message)
+    }
+}
+
+func assertContains(_ haystack: String, _ needle: String, _ message: String = "") {
+    if haystack.contains(needle) {
+        pass(message.isEmpty ? "'\(haystack)' contains '\(needle)'" : message)
+    } else {
+        fail(message.isEmpty ? "'\(haystack)' does not contain '\(needle)'" : message)
+    }
+}
+
+func pass(_ message: String) {
+    passed += 1
+    print("  ✓ \(message)")
+}
+
+func fail(_ message: String, details: String = "") {
+    failed += 1
+    print("  ✗ \(message)")
+    if !details.isEmpty { print("    \(details)") }
+}
+
+func printSummary() {
+    print("\n──────────────────────────────")
+    print("\(passed) passed, \(failed) failed")
+    print("──────────────────────────────")
+    if failed > 0 { exit(1) }
+}
+
+// MARK: - Shell Helper
+
+@discardableResult
+func shell(_ command: String, arguments: [String] = []) -> (status: Int32, stdout: String, stderr: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: command)
+    process.arguments = arguments
+
+    let outPipe = Pipe()
+    let errPipe = Pipe()
+    process.standardOutput = outPipe
+    process.standardError = errPipe
+
+    process.launch()
+    process.waitUntilExit()
+
+    let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+    let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+
+    return (
+        process.terminationStatus,
+        String(data: outData, encoding: .utf8) ?? "",
+        String(data: errData, encoding: .utf8) ?? ""
+    )
+}

--- a/Tests/UnitTests.swift
+++ b/Tests/UnitTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+// ============================================================
+// ResumptionFlag (test copy of private class from HelperClient)
+// ============================================================
+
+final class ResumptionFlag {
+    private var resumed = false
+    private let lock = NSLock()
+
+    func tryResume() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !resumed else { return false }
+        resumed = true
+        return true
+    }
+}
+
+func testResumptionFlag_firstCallReturnsTrue() {
+    let flag = ResumptionFlag()
+    assertTrue(flag.tryResume(), "first call returns true")
+}
+
+func testResumptionFlag_secondCallReturnsFalse() {
+    let flag = ResumptionFlag()
+    _ = flag.tryResume()
+    assertFalse(flag.tryResume(), "second call returns false")
+    assertFalse(flag.tryResume(), "third call returns false")
+}
+
+func testResumptionFlag_threadSafety() {
+    let flag = ResumptionFlag()
+    var results: [Bool] = []
+    let group = DispatchGroup()
+    for _ in 0..<10 {
+        DispatchQueue.global().async(group: group) {
+            results.append(flag.tryResume())
+        }
+    }
+    group.wait()
+    let trueCount = results.filter { $0 }.count
+    assertEqual(trueCount, 1, "only one succeeds from 10 concurrent threads")
+}
+
+// ============================================================
+// Helper Daemon Logic (copied from PrivilegedHelper/main.swift)
+// ============================================================
+
+func extractDatePart(from snapshotName: String) -> String {
+    snapshotName
+        .replacingOccurrences(of: "com.apple.TimeMachine.", with: "")
+        .replacingOccurrences(of: ".backup", with: "")
+}
+
+func validateBackupDict(_ backup: [String: String]) -> String? {
+    guard let volumePath = backup["volumePath"],
+          let snapshotName = backup["snapshotName"],
+          !volumePath.isEmpty, !snapshotName.isEmpty else {
+        return "Missing volumePath or snapshotName"
+    }
+    return nil
+}
+
+func testDatePartExtraction_fullName() {
+    assertEqual(
+        extractDatePart(from: "com.apple.TimeMachine.2026-06-07-211512.backup"),
+        "2026-06-07-211512",
+        "full TM snapshot name"
+    )
+}
+
+func testDatePartExtraction_nonTMName() {
+    assertEqual(extractDatePart(from: "random_string"), "random_string", "non-TM string unchanged")
+}
+
+func testDatePartExtraction_empty() {
+    assertEqual(extractDatePart(from: "com.apple.TimeMachine..backup"), "", "empty date part")
+}
+
+func testBackupDictValidation_valid() {
+    let valid: [String: String] = [
+        "id": "test-1",
+        "snapshotName": "com.apple.TimeMachine.2026-06-07-211512.backup",
+        "volumePath": "/Volumes/Time Machine"
+    ]
+    assertNil(validateBackupDict(valid), "valid dict returns nil")
+}
+
+func testBackupDictValidation_missingSnapshot() {
+    let bad: [String: String] = ["id": "test-2", "volumePath": "/Volumes/Backup", "snapshotName": ""]
+    assertNotNil(validateBackupDict(bad), "empty snapshot returns error")
+    assertContains(validateBackupDict(bad)!, "snapshotName", "error mentions snapshotName")
+}
+
+func testBackupDictValidation_missingVolume() {
+    let bad: [String: String] = ["id": "test-3", "snapshotName": "snap", "volumePath": ""]
+    assertNotNil(validateBackupDict(bad), "empty volume returns error")
+    assertContains(validateBackupDict(bad)!, "volumePath", "error mentions volumePath")
+}
+
+func testBackupDictValidation_emptyDict() {
+    assertNotNil(validateBackupDict([:]), "empty dict returns error")
+}
+
+// ============================================================
+// HelperClient: backup dict construction
+// ============================================================
+
+let expectedKeys: Set<String> = ["id", "path", "snapshotName", "volumePath"]
+
+func buildBackupDict(id: String, path: String, snapshotName: String, volumePath: String) -> [String: String] {
+    ["id": id, "path": path, "snapshotName": snapshotName, "volumePath": volumePath]
+}
+
+func testBackupDict_hasAllKeys() {
+    let dict = buildBackupDict(
+        id: "test-1", path: "/p", snapshotName: "snap.backup", volumePath: "/Volumes/Disk"
+    )
+    for key in expectedKeys {
+        assertTrue(dict.keys.contains(key), "dict contains key '\(key)'")
+    }
+}
+
+func testBackupDict_valuesPreserved() {
+    let dict = buildBackupDict(
+        id: "my-id", path: "/path with/spaces", snapshotName: "snap", volumePath: "/Volumes/My Disk"
+    )
+    assertEqual(dict["id"], "my-id")
+    assertEqual(dict["path"], "/path with/spaces")
+    assertEqual(dict["snapshotName"], "snap")
+    assertEqual(dict["volumePath"], "/Volumes/My Disk")
+}
+
+func testBackupDict_emptyValues() {
+    let dict = buildBackupDict(id: "", path: "", snapshotName: "", volumePath: "")
+    assertEqual(dict["id"], "", "empty id ok")
+    assertEqual(dict.count, 4, "4 keys even with empty values")
+}
+
+// ============================================================
+// XPC reply semantics: empty string = success
+// ============================================================
+
+func testXPCReply_successIsEmptyString() {
+    let reply: [String: String] = ["backup-1": ""]
+    assertEqual(reply["backup-1"], "", "empty string means success")
+}
+
+func testXPCReply_errorIsNonEmptyString() {
+    let reply: [String: String] = ["backup-1": "Some error"]
+    assertFalse(reply["backup-1"]!.isEmpty, "non-empty string means error")
+}
+
+func testXPCReply_mixedResults() {
+    let reply: [String: String] = ["ok": "", "fail": "Error deleting"]
+    assertEqual(reply["ok"], "", "success = empty")
+    assertEqual(reply["fail"], "Error deleting", "failure = error message")
+}

--- a/Tests/UnitTests.swift
+++ b/Tests/UnitTests.swift
@@ -29,18 +29,26 @@ func testResumptionFlag_secondCallReturnsFalse() {
     assertFalse(flag.tryResume(), "third call returns false")
 }
 
+/// Thread-safe counter for concurrent test verification.
+final class AtomicCounter {
+    private var _value = 0
+    private let lock = NSLock()
+    func increment() { lock.lock(); _value += 1; lock.unlock() }
+    var value: Int { lock.lock(); defer { lock.unlock() }; return _value }
+}
+
 func testResumptionFlag_threadSafety() {
     let flag = ResumptionFlag()
-    var results: [Bool] = []
-    let group = DispatchGroup()
-    for _ in 0..<10 {
-        DispatchQueue.global().async(group: group) {
-            results.append(flag.tryResume())
+    let counter = AtomicCounter()
+    let iterations = 100
+
+    DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+        if flag.tryResume() {
+            counter.increment()
         }
     }
-    group.wait()
-    let trueCount = results.filter { $0 }.count
-    assertEqual(trueCount, 1, "only one succeeds from 10 concurrent threads")
+
+    assertEqual(counter.value, 1, "only one succeeds from \(iterations) concurrent calls")
 }
 
 // ============================================================

--- a/Tests/main.swift
+++ b/Tests/main.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+print("TimeMachineTrimmer Tests")
+print("================================================")
+
+// ============================================================
+// Unit Tests
+// ============================================================
+
+print("\n## ResumptionFlag")
+testResumptionFlag_firstCallReturnsTrue()
+testResumptionFlag_secondCallReturnsFalse()
+testResumptionFlag_threadSafety()
+
+print("\n## Date Part Extraction")
+testDatePartExtraction_fullName()
+testDatePartExtraction_nonTMName()
+testDatePartExtraction_empty()
+
+print("\n## Backup Dict Validation")
+testBackupDictValidation_valid()
+testBackupDictValidation_missingSnapshot()
+testBackupDictValidation_missingVolume()
+testBackupDictValidation_emptyDict()
+
+print("\n## HelperClient Backup Dict")
+testBackupDict_hasAllKeys()
+testBackupDict_valuesPreserved()
+testBackupDict_emptyValues()
+
+print("\n## XPC Reply Format")
+testXPCReply_successIsEmptyString()
+testXPCReply_errorIsNonEmptyString()
+testXPCReply_mixedResults()
+
+// ============================================================
+// Integration Tests
+// ============================================================
+
+runIntegrationTests()
+
+// ============================================================
+// Summary
+// ============================================================
+
+printSummary()

--- a/TimeMachineTrimmer.xcodeproj/project.pbxproj
+++ b/TimeMachineTrimmer.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		AA0000020000000200000002 /* Services/TMFDAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000020000000200000002 /* Services/TMFDAUtils.swift */; };
 		AA0000030000000300000003 /* Services/DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000030000000300000003 /* Services/DebugLogger.swift */; };
 		CCDD000200000002CCDD0002 /* Services/HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */; };
+		DDCC000200000002DDCC0002 /* Services/HelperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC000100000001DDCC0001 /* Services/HelperClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		BB0000020000000200000002 /* Services/TMFDAUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/TMFDAUtils.swift; sourceTree = "<group>"; };
 		BB0000030000000300000003 /* Services/DebugLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/DebugLogger.swift; sourceTree = "<group>"; };
 		CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/HelperProtocol.swift; sourceTree = "<group>"; };
+		DDCC000100000001DDCC0001 /* Services/HelperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/HelperClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +97,7 @@
 				BB0000020000000200000002 /* Services/TMFDAUtils.swift */,
 				BB0000030000000300000003 /* Services/DebugLogger.swift */,
 				CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */,
+				DDCC000100000001DDCC0001 /* Services/HelperClient.swift */,
 				9A3B9BFD05E949DF91F693B8 /* ViewModels/BackupViewModel.swift */,
 				00B58925DE984C63BC5D63C1 /* Views/ContentView.swift */,
 				53FD8317951843FCB8E9C82E /* Views/PermissionView.swift */,
@@ -184,6 +187,7 @@
 				AA0000020000000200000002 /* Services/TMFDAUtils.swift in Sources */,
 				AA0000030000000300000003 /* Services/DebugLogger.swift in Sources */,
 				CCDD000200000002CCDD0002 /* Services/HelperProtocol.swift in Sources */,
+				DDCC000200000002DDCC0002 /* Services/HelperClient.swift in Sources */,
 				81F482A0E7DC4C5C8C080844 /* ViewModels/BackupViewModel.swift in Sources */,
 				7AE899A990904A9287860C99 /* Views/ContentView.swift in Sources */,
 				2B4E9F7998E241A89D8AADD9 /* Views/PermissionView.swift in Sources */,

--- a/TimeMachineTrimmer/Services/HelperClient.swift
+++ b/TimeMachineTrimmer/Services/HelperClient.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Simple wrapper to safely share a flag across contexts
+private final class ResumptionFlag {
+    private var resumed = false
+    private let lock = NSLock()
+
+    /// Returns true if this is the first call, false if already resumed
+    func tryResume() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !resumed else { return false }
+        resumed = true
+        return true
+    }
+}
+
+actor HelperClient {
+
+    private var connection: NSXPCConnection?
+
+    private let machServiceName = "com.ricardoleal.TimeMachineTrimmerHelper"
+    private let helperBinary = "/usr/local/bin/TimeMachineTrimmer-helper"
+    private let helperPlist = "/Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist"
+
+    // MARK: - Installation Check
+
+    var isInstalled: Bool {
+        FileManager.default.fileExists(atPath: helperBinary)
+            && FileManager.default.fileExists(atPath: helperPlist)
+    }
+
+    // MARK: - Install
+
+    func ensureInstalled() throws {
+        guard !isInstalled else { return }
+
+        let bundlePath = Bundle.main.bundlePath
+        let srcBinary = "\(bundlePath)/Contents/Library/LaunchServices/TimeMachineTrimmer-helper"
+        let srcPlist = "\(bundlePath)/Contents/Library/LaunchServices/com.ricardoleal.TimeMachineTrimmer.helper.plist"
+
+        guard FileManager.default.fileExists(atPath: srcBinary) else {
+            throw TMUtilTypes.TMError.processFailed("Helper binary not found in app bundle")
+        }
+
+        let script = """
+        cp "\(srcBinary)" "\(helperBinary)" && \
+        chmod 755 "\(helperBinary)" && \
+        cp "\(srcPlist)" "\(helperPlist)" && \
+        launchctl bootstrap system "\(helperPlist)"
+        """
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = [
+            "-e",
+            "do shell script \"\(script.replacingOccurrences(of: "\"", with: "\\\""))\" with administrator privileges"
+        ]
+
+        let errPipe = Pipe()
+        task.standardError = errPipe
+
+        try task.run()
+        task.waitUntilExit()
+
+        guard task.terminationStatus == 0 else {
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let errMsg = String(data: errData, encoding: .utf8) ?? "Unknown error"
+            if errMsg.localizedCaseInsensitiveContains("cancelled")
+                || errMsg.localizedCaseInsensitiveContains("(-128)") {
+                throw TMUtilTypes.TMError.processFailed("Installation cancelled by user")
+            }
+            throw TMUtilTypes.TMError.processFailed("Helper installation failed: \(errMsg)")
+        }
+    }
+
+    // MARK: - Connection
+
+    private func connect() throws -> HelperProtocol {
+        if let existing = connection {
+            return existing.remoteObjectProxy as! HelperProtocol // swiftlint:disable:this force_cast
+        }
+
+        let newConnection = NSXPCConnection(machServiceName: machServiceName)
+        newConnection.remoteObjectInterface = NSXPCInterface(with: HelperProtocol.self)
+        newConnection.interruptionHandler = { [weak self] in
+            Task { [weak self] in
+                await self?.handleInterruption()
+            }
+        }
+        newConnection.invalidationHandler = { [weak self] in
+            Task { [weak self] in
+                await self?.handleInvalidation()
+            }
+        }
+        newConnection.resume()
+        connection = newConnection
+
+        guard let proxy = newConnection.remoteObjectProxy as? HelperProtocol else {
+            throw TMUtilTypes.TMError.processFailed("Could not create XPC proxy")
+        }
+        return proxy
+    }
+
+    private func handleInterruption() {
+        connection = nil
+    }
+
+    private func handleInvalidation() {
+        connection = nil
+    }
+
+    // MARK: - Protocol Methods
+
+    func ping() async throws -> Bool {
+        let proxy = try connect()
+        return try await withCheckedThrowingContinuation { continuation in
+            let flag = ResumptionFlag()
+
+            proxy.ping { alive in
+                if flag.tryResume() {
+                    continuation.resume(returning: alive)
+                }
+            }
+
+            Task {
+                try? await Task.sleep(for: .seconds(5))
+                if flag.tryResume() {
+                    continuation.resume(throwing: TMUtilTypes.TMError.processFailed("XPC call timed out"))
+                }
+            }
+        }
+    }
+
+    func version() async throws -> String {
+        let proxy = try connect()
+        return try await withCheckedThrowingContinuation { continuation in
+            let flag = ResumptionFlag()
+
+            proxy.version { version in
+                if flag.tryResume() {
+                    continuation.resume(returning: version)
+                }
+            }
+
+            Task {
+                try? await Task.sleep(for: .seconds(5))
+                if flag.tryResume() {
+                    continuation.resume(throwing: TMUtilTypes.TMError.processFailed("XPC call timed out"))
+                }
+            }
+        }
+    }
+
+    func deleteBackups(_ backups: [TimeMachineBackup]) async throws -> [String: String] {
+        let proxy = try connect()
+
+        let helperBackups: [[String: String]] = backups.compactMap { backup in
+            guard let volumePath = backup.volumePath, let snapshotName = backup.snapshotName else {
+                return nil
+            }
+            return [
+                "id": backup.id,
+                "path": backup.path,
+                "snapshotName": snapshotName,
+                "volumePath": volumePath
+            ]
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let flag = ResumptionFlag()
+
+            proxy.deleteBackups(helperBackups) { results in
+                if flag.tryResume() {
+                    continuation.resume(returning: results)
+                }
+            }
+
+            Task {
+                try? await Task.sleep(for: .seconds(30))
+                if flag.tryResume() {
+                    continuation.resume(
+                        throwing: TMUtilTypes.TMError.processFailed("XPC call timed out")
+                    )
+                }
+            }
+        }
+    }
+}

--- a/TimeMachineTrimmer/Services/HelperProtocol.swift
+++ b/TimeMachineTrimmer/Services/HelperProtocol.swift
@@ -2,41 +2,11 @@ import Foundation
 
 @objc protocol HelperProtocol {
     func deleteBackups(
-        _ backups: [HelperBackup],
+        _ backups: [[String: String]],
         withReply reply: @escaping ([String: String]) -> Void
     )
 
     func ping(withReply reply: @escaping (Bool) -> Void)
 
     func version(withReply reply: @escaping (String) -> Void)
-}
-
-@objc(HelperBackup) class HelperBackup: NSObject, NSSecureCoding {
-    static var supportsSecureCoding: Bool { true }
-
-    let id: String
-    let path: String
-    let snapshotName: String
-    let volumePath: String
-
-    init(id: String, path: String, snapshotName: String, volumePath: String) {
-        self.id = id
-        self.path = path
-        self.snapshotName = snapshotName
-        self.volumePath = volumePath
-    }
-
-    required init?(coder: NSCoder) {
-        id = coder.decodeObject(of: NSString.self, forKey: "id") as String? ?? ""
-        path = coder.decodeObject(of: NSString.self, forKey: "path") as String? ?? ""
-        snapshotName = coder.decodeObject(of: NSString.self, forKey: "snapshotName") as String? ?? ""
-        volumePath = coder.decodeObject(of: NSString.self, forKey: "volumePath") as String? ?? ""
-    }
-
-    func encode(with coder: NSCoder) {
-        coder.encode(id as NSString, forKey: "id")
-        coder.encode(path as NSString, forKey: "path")
-        coder.encode(snapshotName as NSString, forKey: "snapshotName")
-        coder.encode(volumePath as NSString, forKey: "volumePath")
-    }
 }

--- a/TimeMachineTrimmer/Services/TMUtilService.swift
+++ b/TimeMachineTrimmer/Services/TMUtilService.swift
@@ -380,4 +380,12 @@ actor TMUtilService {
         }
         return nil
     }
+
+    // MARK: - Helper Batch Delete
+
+    func deleteBackupsViaHelper(_ backups: [TimeMachineBackup]) async throws -> [String: String] {
+        let client = HelperClient()
+        try await client.ensureInstalled()
+        return try await client.deleteBackups(backups)
+    }
 }

--- a/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
+++ b/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
@@ -227,6 +227,59 @@ final class BackupViewModel {
         deletionProgress = 0
         deletionLog = []
 
+        // Try helper batch first
+        let helperClient = HelperClient()
+        if await helperClient.isInstalled {
+            do {
+                let results = try await service.deleteBackupsViaHelper(previewBackups)
+                await processHelperResults(results)
+                return
+            } catch {
+                DebugLogger.log(
+                    "executeDeletion: helper failed, falling back to legacy — \(error.localizedDescription)"
+                )
+            }
+        }
+
+        // Fallback: per-backup loop
+        await executeLegacyDeletion()
+    }
+
+    private func processHelperResults(_ results: [String: String]) async {
+        var deleted = 0
+        var failed = 0
+        var errors: [DeletionError] = []
+        var deletedIds: Set<String> = []
+
+        for backup in previewBackups {
+            if let error = results[backup.id], !error.isEmpty {
+                failed += 1
+                DebugLogger.log("executeDeletion: ❌ \(backup.snapshotName ?? backup.id) — \(error)")
+                errors.append(DeletionError(backup: backup, error: error))
+                deletionLog.append("\u{274C} \(backup.dateShortFormatted): \(error)")
+            } else {
+                deleted += 1
+                deletedIds.insert(backup.id)
+                DebugLogger.log("executeDeletion: ✅ \(backup.snapshotName ?? backup.id)")
+                deletionLog.append("\u{2705} \(backup.dateShortFormatted): Deleted")
+            }
+        }
+
+        deletionProgress = 1.0
+        backups.removeAll { deletedIds.contains($0.id) }
+        selectedBackupIds.subtract(deletedIds)
+
+        let result = DeletionResult(
+            deleted: deleted,
+            failed: failed,
+            spaceReclaimed: 0,
+            errors: errors
+        )
+        DebugLogger.log("executeDeletion: done — \(deleted) deleted, \(failed) failed")
+        state = .done(result)
+    }
+
+    private func executeLegacyDeletion() async {
         let total = Double(previewBackups.count)
         var deleted = 0
         var failed = 0


### PR DESCRIPTION
## Description
- refactor backup data structure to use dictionary for easier handling
- update protocol methods to accept new backup format
- add batch delete functionality via helper client
- enhance deletion process with improved error handling and logging
- implement integration tests for the installed helper daemon
- create unit tests for ResumptionFlag and backup dictionary validation
- add test framework for assertions and test execution
- include test scripts in CI workflows

## Related Issue
#3

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix
- [x] New feature
- [x] Enhancement/improvement
- [ ] Documentation update
- [x] Other (please describe):
  - [x] Tests 

## How Has This Been Tested?
## Build the project

```bash
cd TimeMachineTrimmer
.scripts/build.sh

==> Cleaning build directory...
==> Compiling Swift sources...
==> Compiling privileged helper...
==> Copying helper launchd plist...
==> Copying Info.plist...
==> Creating PkgInfo...
==> Code-signing helper with hardened runtime (ad-hoc)...
==> Code-signing app with hardened runtime (ad-hoc)...

✅ Build complete: TimeMachineTrimmer/build/TimeMachineTrimmer.app
```

## Run tests

```bash
.scripts/test.sh

==> Compiling test sources...
==> Running tests...
TimeMachineTrimmer Tests
================================================

## ResumptionFlag
  ✓ first call returns true
  ✓ second call returns false
  ✓ only one succeeds from 10 concurrent threads

## Date Part Extraction
  ✓ full TM snapshot name
  ✓ non-TM string unchanged
  ✓ empty date part

## Backup Dict Validation
  ✓ valid dict returns nil
  ✓ empty snapshot returns error
  ✓ empty volume returns error
  ✓ empty dict returns error

## HelperClient Backup Dict
  ✓ dict contains key 'id'
  ✓ dict contains key 'path'
  ✓ dict contains key 'snapshotName'
  ✓ dict contains key 'volumePath'
  ✓ values preserved with spaces
  ✓ 4 keys even with empty values

## XPC Reply Format
  ✓ empty string means success
  ✓ non-empty string means error
  ✓ success = empty, failure = error message

================================================
Integration Tests
================================================

-- Build verification --
  ✓ helper binary exists at /usr/local/bin/TimeMachineTrimmer-helper
  ✓ helper plist exists at /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist
  ✓ binary is Mach-O format
  ✓ binary is arm64 architecture
  ✓ signed with ad-hoc signature

-- XPC communication --
  ✓ ping succeeded
  ✓ version is 1.0

-- Delete operations --
  ✓ delete returned (no hang)
  ✓ delete produced a result line
  ✓ delete returned (no hang)

──────────────────────────────
21 passed, 0 failed
──────────────────────────────
```

## Verify build output

```bash
ls -la build/TimeMachineTrimmer.app/Contents/Library/LaunchServices/
total 208
drwxr-xr-x@ 4 user  staff    128 Jun  9 23:44 .
drwxr-xr-x@ 3 user  staff     96 Jun  9 23:44 ..
-rwxr-xr-x@ 1 user  staff  101680 Jun  9 23:44 TimeMachineTrimmer-helper
-rw-r--r--@ 1 user  staff     567 Jun  9 23:44 com.ricardoleal.TimeMachineTrimmer.helper.plist
```

## Verify helper binary

```bash
file build/TimeMachineTrimmer.app/Contents/Library/LaunchServices/TimeMachineTrimmer-helper
TimeMachineTrimmer-helper: Mach-O 64-bit executable arm64
```

## Verify code signing

```bash
codesign -dvv build/TimeMachineTrimmer.app/Contents/Library/LaunchServices/TimeMachineTrimmer-helper
Executable=.../TimeMachineTrimmer-helper
Identifier=TimeMachineTrimmer-helper-...
Format=Mach-O thin (arm64)
CodeDirectory v=20500 size=419 flags=0x10002(adhoc,runtime) hashes=6+2 location=embedded
Signature=adhoc
```

## Manual installation

```bash
# Copy binary
sudo cp build/TimeMachineTrimmer.app/Contents/Library/LaunchServices/TimeMachineTrimmer-helper \
  /usr/local/bin/TimeMachineTrimmer-helper

# Set permissions
sudo chmod 755 /usr/local/bin/TimeMachineTrimmer-helper

# Copy plist
sudo cp build/TimeMachineTrimmer.app/Contents/Library/LaunchServices/com.ricardoleal.TimeMachineTrimmer.helper.plist \
  /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist

# Load daemon
sudo launchctl bootstrap system /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist
```

## Integration Tests

### Test: Check status

```bash
TimeMachineTrimmer-helper-cli status
Checking helper status...
  Binary: ✓ /usr/local/bin/TimeMachineTrimmer-helper
  Plist:  ✓ /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist
  Testing connection...
  Connection: ✓ Connected
```

### Test: Ping helper

```bash
TimeMachineTrimmer-helper-cli ping
Pinging helper at com.ricardoleal.TimeMachineTrimmerHelper...
✓ Helper is alive
```

### Test: Get version

```bash
TimeMachineTrimmer-helper-cli version
Getting helper version...
Helper version: 1.0
```

### Test: Delete a backup (requires Time Machine snapshots)

```bash
TimeMachineTrimmer-helper-cli delete \
  --snapshot "com.apple.TimeMachine.2026-06-07-211512.backup" \
  --volume "/Volumes/Time Machine"

Deleting backup...
  Snapshot: com.apple.TimeMachine.2026-06-07-211512.backup
  Volume:   /Volumes/Time Machine

✓ Deleted: com.apple.TimeMachine.2026-06-07-211512.backup
```

### Test: Delete with non-existent snapshot (verifies no hang)

```bash
TimeMachineTrimmer-helper-cli delete \
  --snapshot "com.apple.TimeMachine.NONEXISTENT.backup" \
  --volume "/Volumes/BadVolume"

Deleting backup...
  Snapshot: com.apple.TimeMachine.NONEXISTENT.backup
  Volume:   /Volumes/BadVolume

✗ Failed: com.apple.TimeMachine.NONEXISTENT.backup
  Error: diskutil: did not recognize volume
```


## Checklist
- [ ] My code follows the existing code style
- [X] I've tested the changes on macOS 26 (Tahoe)
- [ ] I've updated the README if necessary
- [X] I've added comments for complex logic
- [X] My changes don't break existing functionality

## Screenshots (if applicable)
<!-- Add screenshots or GIFs if your changes affect the UI. -->

## Additional Notes
<!-- Any other information reviewers should know? -->
