### PR TITLE
feat(viewmodels): implement batch deletion handling in BackupViewModel

### DIFF
--- a/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
+++ b/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
@@ -83,6 +83,7 @@ final class BackupViewModel {
     var selectedBackupIds: Set<String> = []
     var deletionProgress: Double = 0
     var deletionLog: [String] = []
+    var isBatchDeletion: Bool = false
     var errorMessage: String?
     var searchQuery: String = ""
     var tmBackupRunning: Bool = false
@@ -230,6 +231,8 @@ final class BackupViewModel {
         // Try helper batch first
         let helperClient = HelperClient()
         if await helperClient.isInstalled {
+            isBatchDeletion = true
+            deletionLog.append("Sending \(previewBackups.count) backup(s) to privileged helper...")
             do {
                 let results = try await service.deleteBackupsViaHelper(previewBackups)
                 await processHelperResults(results)
@@ -246,6 +249,7 @@ final class BackupViewModel {
     }
 
     private func processHelperResults(_ results: [String: String]) async {
+        isBatchDeletion = false
         var deleted = 0
         var failed = 0
         var errors: [DeletionError] = []
@@ -322,6 +326,7 @@ final class BackupViewModel {
         selectedBackupIds = []
         deletionProgress = 0
         deletionLog = []
+        isBatchDeletion = false
     }
 
     func toggleBackupSelection(_ id: String) {

--- a/TimeMachineTrimmer/Views/ProgressSheet.swift
+++ b/TimeMachineTrimmer/Views/ProgressSheet.swift
@@ -13,15 +13,21 @@ struct ProgressSheet: View {
                 .font(.title3)
                 .fontWeight(.semibold)
 
-            ProgressView(value: viewModel.deletionProgress) {
-                Text("\(Int(viewModel.deletionProgress * 100))%")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-                    .contentTransition(.numericText())
+            if viewModel.isBatchDeletion {
+                ProgressView()
+                    .progressViewStyle(.linear)
+                    .padding(.horizontal)
+            } else {
+                ProgressView(value: viewModel.deletionProgress) {
+                    Text("\(Int(viewModel.deletionProgress * 100))%")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                }
+                .progressViewStyle(.linear)
+                .padding(.horizontal)
             }
-            .progressViewStyle(.linear)
-            .padding(.horizontal)
 
             logSection
         }


### PR DESCRIPTION
## Description
- add isBatchDeletion property to track batch deletion state
- update deletion log to indicate when backups are sent to the helper
- adjust ProgressSheet to display progress based on batch deletion state

## Related Issue
#4 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ X] Enhancement/improvement
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
<img width="960" height="552" alt="Kapture 2026-06-10 at 13 27 19" src="https://github.com/user-attachments/assets/04de8206-25fd-4efc-8ec1-46d77414047f" />


## Checklist
- [ ] My code follows the existing code style
- [X] I've tested the changes on macOS 26 (Tahoe)
- [ ] I've updated the README if necessary
- [ ] I've added comments for complex logic
- [ ] My changes don't break existing functionality
