### PR TITLE
feat(menu-bar): add menu bar icon for background operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,12 @@ A macOS utility app that deletes Time Machine snapshots. Built with Swift + Swif
 
 ### Key Naming
 
-| Item | Value |
-|---|---|
-| Helper binary | `/usr/local/bin/TimeMachineTrimmer-helper` |
-| Launchd label | `com.ricardoleal.TimeMachineTrimmer.helper` |
-| XPC Mach service | `com.ricardoleal.TimeMachineTrimmerHelper` |
-| Launchd plist | `/Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist` |
+| Item             | Value                                                                    |
+| ---------------- | ------------------------------------------------------------------------ |
+| Helper binary    | `/usr/local/bin/TimeMachineTrimmer-helper`                               |
+| Launchd label    | `com.ricardoleal.TimeMachineTrimmer.helper`                              |
+| Launchd plist    | `/Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist` |
+| XPC Mach service | `com.ricardoleal.TimeMachineTrimmerHelper`                               |
 
 ## Workflow
 
@@ -71,13 +71,13 @@ A macOS utility app that deletes Time Machine snapshots. Built with Swift + Swif
 
 ## Commands
 
-| Action | Command |
-|---|---|
-| Build app + helper | `.scripts/build.sh` |
-| Build debug only | `.scripts/build_debug.sh` |
-| Lint | `swiftlint --strict` |
-| Run tests | `.scripts/test.sh` |
-| Package DMG | `.scripts/package_dmg.sh` |
+| Action             | Command                   |
+| ------------------ | ------------------------- |
+| Build app + helper | `.scripts/build.sh`       |
+| Build debug only   | `.scripts/build_debug.sh` |
+| Lint               | `swiftlint --strict`      |
+| Package DMG        | `.scripts/package_dmg.sh` |
+| Run tests          | `.scripts/test.sh`        |
 
 ### Build requirements
 
@@ -113,6 +113,7 @@ Tests/
 - Privileged helper compiles `HelperProtocol.swift` from the **app source directory** (`$SRC_DIR/Services/HelperProtocol.swift`), not from `PrivilegedHelper/`
 - When adding new Swift source files to the app target, update both `build.sh` (which globs `find "$SRC_DIR" -name "*.swift"`) AND `project.pbxproj`
 - `AGENTS.md`, `.github/`, `.scripts/`, `build/`, `Tests/TEST-RESULTS.md` are documentation/infrastructure — do not reference in production code
+- **Menu bar icon uses AppKit `NSStatusItem`** (via `MenuBarManager.swift`) — SwiftUI `MenuBarExtra(.menu)` does not render dropdown items on macOS 26.5.1 Tahoe. Do NOT use SwiftUI `MenuBarExtra` for the menu bar.
 
 ## Before Submitting Changes
 

--- a/TimeMachineTrimmer.xcodeproj/project.pbxproj
+++ b/TimeMachineTrimmer.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		AA0000030000000300000003 /* Services/DebugLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000030000000300000003 /* Services/DebugLogger.swift */; };
 		CCDD000200000002CCDD0002 /* Services/HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */; };
 		DDCC000200000002DDCC0002 /* Services/HelperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC000100000001DDCC0001 /* Services/HelperClient.swift */; };
+		BB1122334455667788990022 /* Services/MenuBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1122334455667788990011 /* Services/MenuBarManager.swift */; };
+		CC1122334455667788990033 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1122334455667788990044 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +58,8 @@
 		BB0000030000000300000003 /* Services/DebugLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/DebugLogger.swift; sourceTree = "<group>"; };
 		CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/HelperProtocol.swift; sourceTree = "<group>"; };
 		DDCC000100000001DDCC0001 /* Services/HelperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/HelperClient.swift; sourceTree = "<group>"; };
+		AA1122334455667788990011 /* Services/MenuBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/MenuBarManager.swift; sourceTree = "<group>"; };
+		DD1122334455667788990044 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +102,8 @@
 				BB0000030000000300000003 /* Services/DebugLogger.swift */,
 				CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */,
 				DDCC000100000001DDCC0001 /* Services/HelperClient.swift */,
+				AA1122334455667788990011 /* Services/MenuBarManager.swift */,
+				DD1122334455667788990044 /* AppDelegate.swift */,
 				9A3B9BFD05E949DF91F693B8 /* ViewModels/BackupViewModel.swift */,
 				00B58925DE984C63BC5D63C1 /* Views/ContentView.swift */,
 				53FD8317951843FCB8E9C82E /* Views/PermissionView.swift */,
@@ -188,6 +194,8 @@
 				AA0000030000000300000003 /* Services/DebugLogger.swift in Sources */,
 				CCDD000200000002CCDD0002 /* Services/HelperProtocol.swift in Sources */,
 				DDCC000200000002DDCC0002 /* Services/HelperClient.swift in Sources */,
+				BB1122334455667788990022 /* Services/MenuBarManager.swift in Sources */,
+				CC1122334455667788990033 /* AppDelegate.swift in Sources */,
 				81F482A0E7DC4C5C8C080844 /* ViewModels/BackupViewModel.swift in Sources */,
 				7AE899A990904A9287860C99 /* Views/ContentView.swift in Sources */,
 				2B4E9F7998E241A89D8AADD9 /* Views/PermissionView.swift in Sources */,

--- a/TimeMachineTrimmer.xcodeproj/project.pbxproj
+++ b/TimeMachineTrimmer.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		DDCC000200000002DDCC0002 /* Services/HelperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC000100000001DDCC0001 /* Services/HelperClient.swift */; };
 		BB1122334455667788990022 /* Services/MenuBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1122334455667788990011 /* Services/MenuBarManager.swift */; };
 		CC1122334455667788990033 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1122334455667788990044 /* AppDelegate.swift */; };
+		EE0000010000000100000001 /* Models/SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000100000001 /* Models/SettingsStore.swift */; };
+		EE0000020000000200000002 /* Views/SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000020000000200000002 /* Views/SettingsView.swift */; };
+		EE0000030000000300000003 /* Views/TrimNowSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000030000000300000003 /* Views/TrimNowSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +63,9 @@
 		DDCC000100000001DDCC0001 /* Services/HelperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/HelperClient.swift; sourceTree = "<group>"; };
 		AA1122334455667788990011 /* Services/MenuBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/MenuBarManager.swift; sourceTree = "<group>"; };
 		DD1122334455667788990044 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		FF0000010000000100000001 /* Models/SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/SettingsStore.swift; sourceTree = "<group>"; };
+		FF0000020000000200000002 /* Views/SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/SettingsView.swift; sourceTree = "<group>"; };
+		FF0000030000000300000003 /* Views/TrimNowSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/TrimNowSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,9 +120,12 @@
 				2D77DA54FBEF469B9E099014 /* Views/PreviewSheet.swift */,
 				64636D63414C4C4F8CAC5F49 /* Views/ProgressSheet.swift */,
 				1195F9D461674DCE948AC54C /* Views/ResultSheet.swift */,
+				FF0000020000000200000002 /* Views/SettingsView.swift */,
+				FF0000030000000300000003 /* Views/TrimNowSheet.swift */,
 				C1C358C4EF954CC991B4E0DD /* Info.plist */,
 				AABBCCDDEEFF001122334455 /* Assets.xcassets */,
 				EB96D981D6ED428193FCD0CB /* Models/ByteCountFormatter+Extensions.swift */,
+				FF0000010000000100000001 /* Models/SettingsStore.swift */,
 			);
 			path = TimeMachineTrimmer;
 			sourceTree = "<group>";
@@ -207,6 +216,9 @@
 				272F311BCD4A46C58A35C073 /* Views/ProgressSheet.swift in Sources */,
 				C5107FBC43AD4904A679E94A /* Views/ResultSheet.swift in Sources */,
 				8720A2E0A490428DAED0AD5E /* Models/ByteCountFormatter+Extensions.swift in Sources */,
+				EE0000010000000100000001 /* Models/SettingsStore.swift in Sources */,
+				EE0000020000000200000002 /* Views/SettingsView.swift in Sources */,
+				EE0000030000000300000003 /* Views/TrimNowSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TimeMachineTrimmer/AppDelegate.swift
+++ b/TimeMachineTrimmer/AppDelegate.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var hasLaunched = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+
+        let settings = SettingsStore.shared
+        if settings.showWindowOnLaunch {
+            WindowSetup.mainWindow?.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+        } else if !hasLaunched {
+            hasLaunched = true
+            let alert = NSAlert()
+            alert.messageText = "TimeMachineTrimmer"
+            alert.informativeText = "Running in your menu bar."
+            alert.runModal()
+        }
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows flag: Bool
+    ) -> Bool {
+        if !flag {
+            NSApp.unhide(nil)
+            WindowSetup.mainWindow?.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+        }
+        return true
+    }
+}

--- a/TimeMachineTrimmer/Models/SettingsStore.swift
+++ b/TimeMachineTrimmer/Models/SettingsStore.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+@MainActor
+@Observable
+final class SettingsStore {
+    static let shared = SettingsStore()
+
+    var showWindowOnLaunch: Bool {
+        get { _showWindowOnLaunch }
+        set { _showWindowOnLaunch = newValue; UserDefaults.standard.set(newValue, forKey: "showWindowOnLaunch") }
+    }
+    var ageThresholdMonths: Int {
+        get { _ageThresholdMonths }
+        set { _ageThresholdMonths = newValue; UserDefaults.standard.set(newValue, forKey: "ageThresholdMonths") }
+    }
+    var lastTrimDate: Date? {
+        get { _lastTrimDate }
+        set {
+            _lastTrimDate = newValue
+            if let date = newValue {
+                UserDefaults.standard.set(date, forKey: "lastTrimDate")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "lastTrimDate")
+            }
+        }
+    }
+    var lastTrimSummary: String {
+        get { _lastTrimSummary }
+        set { _lastTrimSummary = newValue; UserDefaults.standard.set(newValue, forKey: "lastTrimSummary") }
+    }
+    var trimNotifyOnComplete: Bool {
+        get { _trimNotifyOnComplete }
+        set { _trimNotifyOnComplete = newValue; UserDefaults.standard.set(newValue, forKey: "trimNotifyOnComplete") }
+    }
+
+    @ObservationIgnored private var _showWindowOnLaunch: Bool
+    @ObservationIgnored private var _ageThresholdMonths: Int
+    @ObservationIgnored private var _lastTrimDate: Date?
+    @ObservationIgnored private var _lastTrimSummary: String
+    @ObservationIgnored private var _trimNotifyOnComplete: Bool
+
+    private init() {
+        let defaults = UserDefaults.standard
+        _showWindowOnLaunch = defaults.bool(forKey: "showWindowOnLaunch")
+        _ageThresholdMonths = defaults.object(forKey: "ageThresholdMonths") as? Int ?? 6
+        _lastTrimDate = defaults.object(forKey: "lastTrimDate") as? Date
+        _lastTrimSummary = defaults.string(forKey: "lastTrimSummary") ?? ""
+        _trimNotifyOnComplete = defaults.bool(forKey: "trimNotifyOnComplete")
+    }
+
+    func recordTrim(date: Date, count: Int, space: String) {
+        lastTrimDate = date
+        lastTrimSummary = "\(count) snapshots, \(space)"
+    }
+
+    func clearTrimHistory() {
+        lastTrimDate = nil
+        lastTrimSummary = ""
+    }
+}

--- a/TimeMachineTrimmer/Services/MenuBarManager.swift
+++ b/TimeMachineTrimmer/Services/MenuBarManager.swift
@@ -1,0 +1,144 @@
+import AppKit
+
+@MainActor
+final class MenuBarManager: NSObject, NSMenuDelegate {
+    private var statusItem: NSStatusItem?
+    private var lastTrimItem: NSMenuItem?
+
+    func setup(
+        onScan: @escaping () -> Void,
+        onShowWindow: @escaping () -> Void,
+        onTrimNow: @escaping () -> Void,
+        onSettings: @escaping () -> Void,
+        onQuit: @escaping () -> Void
+    ) {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem?.button?.image = NSImage(
+            systemSymbolName: "scissors",
+            accessibilityDescription: "TimeMachineTrimmer"
+        )
+        statusItem?.button?.image?.isTemplate = true
+        statusItem?.menu = buildMenu()
+
+        self.onScan = onScan
+        self.onShowWindow = onShowWindow
+        self.onTrimNow = onTrimNow
+        self.onSettings = onSettings
+        self.onQuit = onQuit
+    }
+
+    private func buildMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.delegate = self
+        addTopMenuItems(to: menu)
+        menu.addItem(NSMenuItem.separator())
+        addBottomMenuItems(to: menu)
+        return menu
+    }
+
+    private func addTopMenuItems(to menu: NSMenu) {
+        let trimItem = NSMenuItem(
+            title: "Trim Now\u{2026}",
+            action: #selector(trimNow(_:)),
+            keyEquivalent: "t"
+        )
+        trimItem.keyEquivalentModifierMask = [.command, .shift]
+        trimItem.target = self
+        menu.addItem(trimItem)
+
+        let showItem = NSMenuItem(
+            title: "Open Main Window",
+            action: #selector(showWindow(_:)),
+            keyEquivalent: "o"
+        )
+        showItem.keyEquivalentModifierMask = [.command, .shift]
+        showItem.target = self
+        menu.addItem(showItem)
+
+        let lastTrimItem = NSMenuItem(
+            title: lastTrimTitle,
+            action: nil,
+            keyEquivalent: ""
+        )
+        lastTrimItem.isEnabled = false
+        self.lastTrimItem = lastTrimItem
+        menu.addItem(lastTrimItem)
+    }
+
+    private func addBottomMenuItems(to menu: NSMenu) {
+        let scanItem = NSMenuItem(
+            title: "Scan Backups",
+            action: #selector(scanBackups(_:)),
+            keyEquivalent: "r"
+        )
+        scanItem.target = self
+        menu.addItem(scanItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let settingsItem = NSMenuItem(
+            title: "Settings\u{2026}",
+            action: #selector(settingsAction(_:)),
+            keyEquivalent: ","
+        )
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let quitItem = NSMenuItem(
+            title: "Quit TimeMachineTrimmer",
+            action: #selector(quitApp(_:)),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        menu.addItem(quitItem)
+    }
+
+    private var onScan: (() -> Void)?
+    private var onShowWindow: (() -> Void)?
+    private var onTrimNow: (() -> Void)?
+    private var onSettings: (() -> Void)?
+    private var onQuit: (() -> Void)?
+
+    private var lastTrimTitle: String {
+        let settings = SettingsStore.shared
+        if let date = settings.lastTrimDate {
+            let dateStr = date.formatted(date: .abbreviated, time: .omitted)
+            return "Last trim: \(dateStr) \u{2014} \(settings.lastTrimSummary)"
+        }
+        return "Last trim: never"
+    }
+
+    // MARK: - NSMenuDelegate
+
+    func menuWillOpen(_ menu: NSMenu) {
+        lastTrimItem?.title = lastTrimTitle
+    }
+
+    // MARK: - Actions
+
+    @objc private func showWindow(_ sender: Any?) {
+        DebugLogger.log("menuBar: Open Main Window clicked")
+        onShowWindow?()
+    }
+
+    @objc private func trimNow(_ sender: Any?) {
+        DebugLogger.log("menuBar: Trim Now clicked")
+        onTrimNow?()
+    }
+
+    @objc private func scanBackups(_ sender: Any?) {
+        DebugLogger.log("menuBar: Scan Backups clicked")
+        onScan?()
+    }
+
+    @objc private func settingsAction(_ sender: Any?) {
+        DebugLogger.log("menuBar: Settings clicked")
+        onSettings?()
+    }
+
+    @objc private func quitApp(_ sender: Any?) {
+        NSApp.terminate(nil)
+    }
+}

--- a/TimeMachineTrimmer/TimeMachineTrimmerApp.swift
+++ b/TimeMachineTrimmer/TimeMachineTrimmerApp.swift
@@ -2,10 +2,12 @@ import SwiftUI
 
 @main
 struct TimeMachineTrimmerApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var viewModel = BackupViewModel()
+    private let menuBarManager = MenuBarManager()
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: "main") {
             ContentView()
                 .environment(viewModel)
                 .frame(minWidth: 720, minHeight: 520)
@@ -42,5 +44,37 @@ struct TimeMachineTrimmerApp: App {
                 .disabled(viewModel.state != .scanned)
             }
         }
+        .onChange(of: true) { _, _ in }
+    }
+
+    init() {
+        menuBarManager.setup(
+            onScan: {
+                NSApp.unhide(nil)
+                NSApp.activate()
+                WindowSetup.mainWindow?.makeKeyAndOrderFront(nil)
+                NotificationCenter.default.post(name: NSNotification.Name("menuBarScan"), object: nil)
+            },
+            onShowWindow: {
+                NSApp.unhide(nil)
+                NSApp.activate()
+                WindowSetup.mainWindow?.makeKeyAndOrderFront(nil)
+            },
+            onTrimNow: {
+                NSApp.unhide(nil)
+                NSApp.activate()
+                WindowSetup.mainWindow?.makeKeyAndOrderFront(nil)
+                NotificationCenter.default.post(name: NSNotification.Name("menuBarTrimNow"), object: nil)
+            },
+            onSettings: {
+                NSApp.unhide(nil)
+                NSApp.activate()
+                WindowSetup.mainWindow?.makeKeyAndOrderFront(nil)
+                NotificationCenter.default.post(name: NSNotification.Name("menuBarOpenSettings"), object: nil)
+            },
+            onQuit: {
+                NSApp.terminate(nil)
+            }
+        )
     }
 }

--- a/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
+++ b/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
@@ -92,6 +92,7 @@ final class BackupViewModel {
     var backupPhase: String = ""
     var backupFiles: Int = 0
     var backupTotalFiles: Int = 0
+    var isTrimNowActive: Bool = false
 
     var filteredBackups: [TimeMachineBackup] {
         guard !searchQuery.isEmpty else { return backups }
@@ -280,6 +281,9 @@ final class BackupViewModel {
             errors: errors
         )
         DebugLogger.log("executeDeletion: done — \(deleted) deleted, \(failed) failed")
+        if deleted > 0 {
+            SettingsStore.shared.recordTrim(date: Date(), count: deleted, space: "")
+        }
         state = .done(result)
     }
 
@@ -317,6 +321,9 @@ final class BackupViewModel {
             errors: errors
         )
         DebugLogger.log("executeDeletion: done — \(deleted) deleted, \(failed) failed")
+        if deleted > 0 {
+            SettingsStore.shared.recordTrim(date: Date(), count: deleted, space: "")
+        }
         state = .done(result)
     }
 
@@ -327,6 +334,7 @@ final class BackupViewModel {
         deletionProgress = 0
         deletionLog = []
         isBatchDeletion = false
+        isTrimNowActive = false
     }
 
     func toggleBackupSelection(_ id: String) {
@@ -343,5 +351,42 @@ final class BackupViewModel {
 
     func deselectAllBackups() {
         selectedBackupIds.removeAll()
+    }
+
+    func quickTrimNow(thresholdMonths: Int) async -> DeletionResult? {
+        DebugLogger.log("quickTrimNow: threshold=\(thresholdMonths)")
+        isTrimNowActive = true
+        ageThresholdMonths = thresholdMonths
+        selectedMethod = .age
+
+        if !TMFDAUtils.checkFDA() {
+            needsPermissionSheet = true
+            isTrimNowActive = false
+            return nil
+        }
+
+        await scanBackups()
+        guard state == .scanned else {
+            isTrimNowActive = false
+            return nil
+        }
+
+        updateAgeSelection()
+
+        guard !selectedBackupIds.isEmpty else {
+            DebugLogger.log("quickTrimNow: no backups match threshold")
+            isTrimNowActive = false
+            return nil
+        }
+
+        previewBackups = backups.filter { selectedBackupIds.contains($0.id) }
+        await executeDeletion()
+
+        guard case .done(let result) = state else {
+            isTrimNowActive = false
+            return nil
+        }
+
+        return result
     }
 }

--- a/TimeMachineTrimmer/Views/ContentView.swift
+++ b/TimeMachineTrimmer/Views/ContentView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(BackupViewModel.self) private var viewModel
+    @State private var showTrimNowSheet = false
+    @State private var showSettingsSheet = false
 
     var body: some View {
         ZStack {
@@ -28,6 +30,13 @@ struct ContentView: View {
                 .onAppear {
                     viewModel.loadDestinations()
                     viewModel.startStatusPolling()
+                    NotificationCenter.default.addObserver(
+                        forName: NSNotification.Name("menuBarScan"),
+                        object: nil,
+                        queue: .main
+                    ) { _ in
+                        Task { await viewModel.checkPermissionsAndScan() }
+                    }
                 }
 
             Color.clear
@@ -40,7 +49,7 @@ struct ContentView: View {
                     ProgressSheet()
                         .interactiveDismissDisabled()
                 }
-            if case .done = viewModel.state {
+            if case .done = viewModel.state, !viewModel.isTrimNowActive {
                 Color.clear
                     .sheet(isPresented: .constant(true)) {
                         ResultSheet()
@@ -58,12 +67,28 @@ struct ContentView: View {
         .sheet(isPresented: Bindable(viewModel).needsPermissionSheet) {
             PermissionView()
         }
+        .sheet(isPresented: $showTrimNowSheet) {
+            TrimNowSheet()
+                .environment(viewModel)
+        }
+        .sheet(isPresented: $showSettingsSheet) {
+            SettingsView()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("menuBarTrimNow"))) { _ in
+            showTrimNowSheet = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("menuBarOpenSettings"))) { _ in
+            showSettingsSheet = true
+        }
         .background(WindowSetup())
         .tint(Color.accentTeal)
     }
 }
 
 struct WindowSetup: NSViewRepresentable {
+    private static let closeDelegate = WindowCloseDelegate()
+    static var mainWindow: NSWindow?
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         DispatchQueue.main.async {
@@ -73,10 +98,20 @@ struct WindowSetup: NSViewRepresentable {
                 window.styleMask.insert(.fullSizeContentView)
                 window.setContentSize(NSSize(width: 960, height: 520))
                 window.minSize = NSSize(width: 760, height: 400)
+                window.isReleasedWhenClosed = false
+                window.delegate = Self.closeDelegate
+                Self.mainWindow = window
             }
         }
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+private class WindowCloseDelegate: NSObject, NSWindowDelegate {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        sender.orderOut(nil)
+        return false
+    }
 }

--- a/TimeMachineTrimmer/Views/SettingsView.swift
+++ b/TimeMachineTrimmer/Views/SettingsView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var settings = SettingsStore.shared
+    @State private var helperStatus: String = "Checking..."
+    @State private var showClearConfirm = false
+
+    private let formatter: ByteCountFormatter = {
+        let fmt = ByteCountFormatter()
+        fmt.countStyle = .file
+        return fmt
+    }()
+
+    var body: some View {
+        TabView {
+            trimDefaultsTab
+                .tabItem { Label("Trim", systemImage: "scissors") }
+
+            helperTab
+                .tabItem { Label("Helper", systemImage: "shield.lefthalf.filled") }
+
+            generalTab
+                .tabItem { Label("General", systemImage: "gearshape") }
+        }
+        .frame(width: 480, height: 340)
+        .onAppear { checkHelper() }
+    }
+
+    // MARK: - Trim Defaults
+
+    private var trimDefaultsTab: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Age threshold:")
+                        Spacer()
+                        Text("\(settings.ageThresholdMonths) months")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                    Slider(value: Binding(
+                        get: { Double(settings.ageThresholdMonths) },
+                        set: { settings.ageThresholdMonths = Int($0) }
+                    ), in: 1...24, step: 1)
+                    Text("\"Trim Now\" will delete snapshots older than this.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.vertical, 4)
+            } header: {
+                Label("Quick Trim Defaults", systemImage: "clock")
+            }
+
+            Section {
+                Toggle("Show notification when trim completes", isOn: $settings.trimNotifyOnComplete)
+            } header: {
+                Label("Notifications", systemImage: "bell")
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Helper
+
+    private var helperTab: some View {
+        Form {
+            Section {
+                HStack {
+                    Text("Status:")
+                    Text(helperStatus)
+                        .foregroundStyle(helperStatus == "Installed" ? .green : .red)
+                }
+
+                if helperStatus == "Installed" {
+                    Button("Uninstall Helper", role: .destructive) {
+                        uninstallHelper()
+                    }
+                } else {
+                    Button("Install Helper") {
+                        installHelper()
+                    }
+                }
+            } header: {
+                Label("Privileged Helper", systemImage: "shield.lefthalf.filled")
+            }
+
+            Section {
+                Text("The helper runs as root and performs backup deletion. "
+                     + "It is installed via an admin-privileged script.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - General
+
+    private var generalTab: some View {
+        Form {
+            Section {
+                Toggle("Show main window on launch", isOn: $settings.showWindowOnLaunch)
+            } header: {
+                Label("Launch Behavior", systemImage: "power")
+            }
+
+            Section {
+                if let date = settings.lastTrimDate {
+                    HStack {
+                        Text("Last trim:")
+                        Spacer()
+                        Text(date.formatted(date: .long, time: .shortened))
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Text("Result:")
+                        Spacer()
+                        Text(settings.lastTrimSummary)
+                            .foregroundStyle(.secondary)
+                    }
+                    Button("Clear History", role: .destructive) {
+                        showClearConfirm = true
+                    }
+                    .confirmationDialog(
+                        "Clear trim history?",
+                        isPresented: $showClearConfirm
+                    ) {
+                        Button("Clear", role: .destructive) { settings.clearTrimHistory() }
+                        Button("Cancel", role: .cancel) {}
+                    } message: {
+                        Text("The last trim date and summary will be removed.")
+                    }
+                } else {
+                    Text("No trim history recorded yet.")
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Label("Trim History", systemImage: "clock.arrow.circlepath")
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Helper Actions
+
+    private func checkHelper() {
+        Task {
+            let client = HelperClient()
+            helperStatus = await client.isInstalled ? "Installed" : "Not installed"
+        }
+    }
+
+    private func installHelper() {
+        let scriptPath = ".scripts/install_helper.sh"
+        let fullPath = (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent(scriptPath)
+        guard FileManager.default.fileExists(atPath: fullPath) else {
+            helperStatus = "Script not found: \(scriptPath)"
+            return
+        }
+        let process = Process()
+        process.launchPath = "/bin/bash"
+        process.arguments = [fullPath]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        process.launch()
+        process.waitUntilExit()
+        helperStatus = process.terminationStatus == 0 ? "Installed" : "Install failed"
+    }
+
+    private func uninstallHelper() {
+        let scriptPath = ".scripts/uninstall_helper.sh"
+        let fullPath = (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent(scriptPath)
+        if FileManager.default.fileExists(atPath: fullPath) {
+            let process = Process()
+            process.launchPath = "/bin/bash"
+            process.arguments = [fullPath]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            process.launch()
+            process.waitUntilExit()
+            helperStatus = process.terminationStatus == 0 ? "Not installed" : "Uninstall failed"
+        } else {
+            // Fallback via osascript
+            // swiftlint:disable:next line_length
+            let script = "do shell script \"launchctl unload /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist; rm -f /usr/local/bin/TimeMachineTrimmer-helper /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist\" with administrator privileges"
+            var error: NSDictionary?
+            NSAppleScript(source: script)?.executeAndReturnError(&error)
+            helperStatus = "Not installed"
+        }
+    }
+}

--- a/TimeMachineTrimmer/Views/TrimNowSheet.swift
+++ b/TimeMachineTrimmer/Views/TrimNowSheet.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+
+private enum TrimPhase {
+    case configure
+    case running
+    case done(BackupViewModel.DeletionResult)
+}
+
+struct TrimNowSheet: View {
+    @Environment(BackupViewModel.self) private var viewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var phase: TrimPhase = .configure
+    @State private var threshold: Int = SettingsStore.shared.ageThresholdMonths
+    @State private var progressText: String = ""
+
+    private let formatter = ByteCountFormatter()
+
+    private var isRunning: Bool {
+        if case .running = phase { true } else { false }
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            switch phase {
+            case .configure:
+                configureView
+            case .running:
+                runningView
+            case .done(let result):
+                doneView(result)
+            }
+        }
+        .frame(width: 380)
+        .padding(24)
+        .interactiveDismissDisabled(isRunning)
+        .onDisappear {
+            viewModel.isTrimNowActive = false
+        }
+    }
+
+    // MARK: - Configure
+
+    private var configureView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.title)
+                .foregroundStyle(.secondary)
+
+            Text("Trim Backups")
+                .font(.headline)
+
+            Text("Delete snapshots older than \(threshold) months")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Text("1")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Slider(value: Binding(
+                    get: { Double(threshold) },
+                    set: { threshold = Int($0) }
+                ), in: 1...24, step: 1)
+                Text("24")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Text("\(threshold) months")
+                .font(.title3)
+                .fontWeight(.medium)
+                .monospacedDigit()
+                .contentTransition(.numericText())
+
+            HStack(spacing: 12) {
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .keyboardShortcut(.escape)
+
+                Button("Trim") {
+                    startTrim()
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+            }
+            .padding(.top, 8)
+        }
+    }
+
+    // MARK: - Running
+
+    private var runningView: some View {
+        VStack(spacing: 24) {
+            ProgressView()
+                .scaleEffect(1.2)
+
+            Text("Trimming backups...")
+                .font(.headline)
+
+            if !progressText.isEmpty {
+                Text(progressText)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    // MARK: - Done
+
+    private func doneView(_ result: BackupViewModel.DeletionResult) -> some View {
+        VStack(spacing: 20) {
+            Image(systemName: result.failed > 0 ? "exclamationmark.triangle" : "checkmark.circle.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(result.failed > 0 ? .orange : .green)
+
+            Text(result.failed > 0 ? "Trim completed with errors" : "Trim completed")
+                .font(.headline)
+
+            HStack(spacing: 24) {
+                VStack {
+                    Text("\(result.deleted)")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                    Text("Deleted")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if result.failed > 0 {
+                    VStack {
+                        Text("\(result.failed)")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.orange)
+                        Text("Failed")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+
+            Button("Done") {
+                viewModel.reset()
+                dismiss()
+            }
+            .keyboardShortcut(.return)
+            .padding(.top, 4)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func startTrim() {
+        phase = .running
+        progressText = "Scanning backups..."
+
+        Task {
+            let result = await viewModel.quickTrimNow(thresholdMonths: threshold)
+            await MainActor.run {
+                if let result {
+                    if result.deleted > 0 || result.failed > 0 {
+                        SettingsStore.shared.recordTrim(
+                            date: Date(),
+                            count: result.deleted,
+                            space: formatter.string(fromByteCount: result.spaceReclaimed)
+                        )
+                    }
+                    phase = .done(result)
+                } else {
+                    progressText = "No backups to trim"
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        viewModel.reset()
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Implement menu bar manager to handle background operations
- Add settings store to manage application settings
- Create app delegate to manage application lifecycle
- Add trim now functionality with user notifications
- Implement settings view for user preferences

## Related Issue
#5 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix
- [x] New feature
- [x] Enhancement/improvement
- [x] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
```
❯ sh test.sh
==> Compiling test sources...

==> Running tests...
TimeMachineTrimmer Tests
================================================

## ResumptionFlag
  ✓ first call returns true
  ✓ second call returns false
  ✓ third call returns false
  ✓ only one succeeds from 100 concurrent calls

## Date Part Extraction
  ✓ full TM snapshot name
  ✓ non-TM string unchanged
  ✓ empty date part

## Backup Dict Validation
  ✓ valid dict returns nil
  ✓ empty snapshot returns error
  ✓ error mentions snapshotName
  ✓ empty volume returns error
  ✓ error mentions volumePath
  ✓ empty dict returns error

## HelperClient Backup Dict
  ✓ dict contains key 'snapshotName'
  ✓ dict contains key 'volumePath'
  ✓ dict contains key 'id'
  ✓ dict contains key 'path'
  ✓ Optional("my-id") == Optional("my-id")
  ✓ Optional("/path with/spaces") == Optional("/path with/spaces")
  ✓ Optional("snap") == Optional("snap")
  ✓ Optional("/Volumes/My Disk") == Optional("/Volumes/My Disk")
  ✓ empty id ok
  ✓ 4 keys even with empty values

## XPC Reply Format
  ✓ empty string means success
  ✓ non-empty string means error
  ✓ success = empty
  ✓ failure = error message


================================================
Integration Tests
================================================

-- Build verification --
  ✓ binary is Mach-O format
  ✓ binary is arm64 architecture
  ✓ code signature present

-- XPC communication --
  ✓ ping: helper is alive
  ✓ version: XPC response received

-- Delete operations --
  ✓ delete: returned (no hang)
  ✓ delete: produced a result line
  ✓ delete (bad volume): returned (no hang)

──────────────────────────────
35 passed, 0 failed
──────────────────────────────
```

## Checklist
- [ ] My code follows the existing code style
- [x] I've tested the changes on macOS 26 (Tahoe)
- [ ] I've updated the README if necessary
- [ ] I've added comments for complex logic
- [x] My changes don't break existing functionality

## Screenshots (if applicable)
<img width="720" height="360" alt="Kapture 2026-06-11 at 13 15 24" src="https://github.com/user-attachments/assets/42ef5422-01da-4532-90fd-56adb641645b" />


## Additional Notes
<!-- Any other information reviewers should know? -->
