### PR TITLE
feat: auto-trim schedule, TrimNow preview, settings rewrite with segmented tabs

### DIFF
--- a/TimeMachineTrimmer.xcodeproj/project.pbxproj
+++ b/TimeMachineTrimmer.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		CCDD000200000002CCDD0002 /* Services/HelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */; };
 		DDCC000200000002DDCC0002 /* Services/HelperClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC000100000001DDCC0001 /* Services/HelperClient.swift */; };
 		BB1122334455667788990022 /* Services/MenuBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1122334455667788990011 /* Services/MenuBarManager.swift */; };
+		EE0000050000000500000005 /* Services/AutoTrimService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000050000000500000005 /* Services/AutoTrimService.swift */; };
 		CC1122334455667788990033 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1122334455667788990044 /* AppDelegate.swift */; };
 		EE0000010000000100000001 /* Models/SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000100000001 /* Models/SettingsStore.swift */; };
 		EE0000020000000200000002 /* Views/SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000020000000200000002 /* Views/SettingsView.swift */; };
@@ -62,6 +63,7 @@
 		CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/HelperProtocol.swift; sourceTree = "<group>"; };
 		DDCC000100000001DDCC0001 /* Services/HelperClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/HelperClient.swift; sourceTree = "<group>"; };
 		AA1122334455667788990011 /* Services/MenuBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/MenuBarManager.swift; sourceTree = "<group>"; };
+		FF0000050000000500000005 /* Services/AutoTrimService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/AutoTrimService.swift; sourceTree = "<group>"; };
 		DD1122334455667788990044 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FF0000010000000100000001 /* Models/SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/SettingsStore.swift; sourceTree = "<group>"; };
 		FF0000020000000200000002 /* Views/SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/SettingsView.swift; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				CCDD000100000001CCDD0001 /* Services/HelperProtocol.swift */,
 				DDCC000100000001DDCC0001 /* Services/HelperClient.swift */,
 				AA1122334455667788990011 /* Services/MenuBarManager.swift */,
+				FF0000050000000500000005 /* Services/AutoTrimService.swift */,
 				DD1122334455667788990044 /* AppDelegate.swift */,
 				9A3B9BFD05E949DF91F693B8 /* ViewModels/BackupViewModel.swift */,
 				00B58925DE984C63BC5D63C1 /* Views/ContentView.swift */,
@@ -204,6 +207,7 @@
 				CCDD000200000002CCDD0002 /* Services/HelperProtocol.swift in Sources */,
 				DDCC000200000002DDCC0002 /* Services/HelperClient.swift in Sources */,
 				BB1122334455667788990022 /* Services/MenuBarManager.swift in Sources */,
+				EE0000050000000500000005 /* Services/AutoTrimService.swift in Sources */,
 				CC1122334455667788990033 /* AppDelegate.swift in Sources */,
 				81F482A0E7DC4C5C8C080844 /* ViewModels/BackupViewModel.swift in Sources */,
 				7AE899A990904A9287860C99 /* Views/ContentView.swift in Sources */,

--- a/TimeMachineTrimmer/AppDelegate.swift
+++ b/TimeMachineTrimmer/AppDelegate.swift
@@ -6,16 +6,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
 
+        AutoTrimService.shared.start()
+
         let settings = SettingsStore.shared
         if settings.showWindowOnLaunch {
             WindowSetup.mainWindow?.makeKeyAndOrderFront(nil)
             NSApp.activate()
-        } else if !hasLaunched {
-            hasLaunched = true
+        } else {
+            WindowSetup.mainWindow?.orderOut(nil)
+        }
+
+        checkHelperInstallOnLaunch()
+    }
+
+    private func checkHelperInstallOnLaunch() {
+        let client = HelperClient()
+        guard !client.isInstalled else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             let alert = NSAlert()
-            alert.messageText = "TimeMachineTrimmer"
-            alert.informativeText = "Running in your menu bar."
-            alert.runModal()
+            alert.messageText = "Install Privileged Helper"
+            alert.informativeText = "TimeMachineTrimmer needs a privileged helper to delete backups. Install it now?"
+            alert.addButton(withTitle: "Install")
+            alert.addButton(withTitle: "Later")
+            if alert.runModal() == .alertFirstButtonReturn {
+                Task {
+                    do {
+                        try await client.ensureInstalled()
+                        DebugLogger.log("helperInstallOnLaunch: installed successfully")
+                    } catch {
+                        DebugLogger.log("helperInstallOnLaunch: failed — \(error.localizedDescription)")
+                    }
+                }
+            }
         }
     }
 

--- a/TimeMachineTrimmer/Models/SettingsStore.swift
+++ b/TimeMachineTrimmer/Models/SettingsStore.swift
@@ -1,51 +1,120 @@
 import Foundation
 
+enum TrimUnit: String, CaseIterable, Codable {
+    case days = "Days"
+    case weeks = "Weeks"
+    case months = "Months"
+
+    var maxValue: Int {
+        switch self {
+        case .days: 90
+        case .weeks: 52
+        case .months: 24
+        }
+    }
+
+    func displayName(count: Int) -> String {
+        let base: String
+        switch self {
+        case .days: base = "day"
+        case .weeks: base = "week"
+        case .months: base = "month"
+        }
+        return count == 1 ? base : "\(base)s"
+    }
+
+    func cutoffDate(byAdding value: Int, to date: Date = Date()) -> Date {
+        let calendar = Calendar.current
+        switch self {
+        case .days:
+            return calendar.date(byAdding: .day, value: -value, to: date) ?? date
+        case .weeks:
+            return calendar.date(byAdding: .day, value: -value * 7, to: date) ?? date
+        case .months:
+            return calendar.date(byAdding: .month, value: -value, to: date) ?? date
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class SettingsStore {
     static let shared = SettingsStore()
 
-    var showWindowOnLaunch: Bool {
-        get { _showWindowOnLaunch }
-        set { _showWindowOnLaunch = newValue; UserDefaults.standard.set(newValue, forKey: "showWindowOnLaunch") }
+    var showWindowOnLaunch: Bool = false {
+        didSet { UserDefaults.standard.set(showWindowOnLaunch, forKey: "showWindowOnLaunch") }
     }
-    var ageThresholdMonths: Int {
-        get { _ageThresholdMonths }
-        set { _ageThresholdMonths = newValue; UserDefaults.standard.set(newValue, forKey: "ageThresholdMonths") }
+    var trimThresholdValue: Int = 30 {
+        didSet { UserDefaults.standard.set(trimThresholdValue, forKey: "trimThresholdValue") }
+    }
+    var trimThresholdUnit: TrimUnit = .days {
+        didSet { UserDefaults.standard.set(trimThresholdUnit.rawValue, forKey: "trimThresholdUnit") }
     }
     var lastTrimDate: Date? {
-        get { _lastTrimDate }
-        set {
-            _lastTrimDate = newValue
-            if let date = newValue {
+        didSet {
+            if let date = lastTrimDate {
                 UserDefaults.standard.set(date, forKey: "lastTrimDate")
             } else {
                 UserDefaults.standard.removeObject(forKey: "lastTrimDate")
             }
         }
     }
-    var lastTrimSummary: String {
-        get { _lastTrimSummary }
-        set { _lastTrimSummary = newValue; UserDefaults.standard.set(newValue, forKey: "lastTrimSummary") }
+    var lastTrimSummary: String = "" {
+        didSet { UserDefaults.standard.set(lastTrimSummary, forKey: "lastTrimSummary") }
     }
-    var trimNotifyOnComplete: Bool {
-        get { _trimNotifyOnComplete }
-        set { _trimNotifyOnComplete = newValue; UserDefaults.standard.set(newValue, forKey: "trimNotifyOnComplete") }
+    var trimNotifyOnComplete: Bool = false {
+        didSet { UserDefaults.standard.set(trimNotifyOnComplete, forKey: "trimNotifyOnComplete") }
     }
-
-    @ObservationIgnored private var _showWindowOnLaunch: Bool
-    @ObservationIgnored private var _ageThresholdMonths: Int
-    @ObservationIgnored private var _lastTrimDate: Date?
-    @ObservationIgnored private var _lastTrimSummary: String
-    @ObservationIgnored private var _trimNotifyOnComplete: Bool
+    var autoTrimEnabled: Bool = false {
+        didSet { UserDefaults.standard.set(autoTrimEnabled, forKey: "autoTrimEnabled") }
+    }
+    var autoTrimThresholdValue: Int = 90 {
+        didSet { UserDefaults.standard.set(autoTrimThresholdValue, forKey: "autoTrimThresholdValue") }
+    }
+    var autoTrimThresholdUnit: TrimUnit = .days {
+        didSet { UserDefaults.standard.set(autoTrimThresholdUnit.rawValue, forKey: "autoTrimThresholdUnit") }
+    }
+    var autoTrimLastRun: Date? {
+        didSet {
+            if let date = autoTrimLastRun {
+                UserDefaults.standard.set(date, forKey: "autoTrimLastRun")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "autoTrimLastRun")
+            }
+        }
+    }
+    var autoTrimResult: String = "" {
+        didSet { UserDefaults.standard.set(autoTrimResult, forKey: "autoTrimResult") }
+    }
 
     private init() {
         let defaults = UserDefaults.standard
-        _showWindowOnLaunch = defaults.bool(forKey: "showWindowOnLaunch")
-        _ageThresholdMonths = defaults.object(forKey: "ageThresholdMonths") as? Int ?? 6
-        _lastTrimDate = defaults.object(forKey: "lastTrimDate") as? Date
-        _lastTrimSummary = defaults.string(forKey: "lastTrimSummary") ?? ""
-        _trimNotifyOnComplete = defaults.bool(forKey: "trimNotifyOnComplete")
+        showWindowOnLaunch = defaults.bool(forKey: "showWindowOnLaunch")
+
+        if let raw = defaults.string(forKey: "trimThresholdUnit"), let unit = TrimUnit(rawValue: raw) {
+            trimThresholdUnit = unit
+        } else {
+            trimThresholdUnit = .days
+        }
+        trimThresholdValue = defaults.object(forKey: "trimThresholdValue") as? Int ?? 30
+
+        lastTrimDate = defaults.object(forKey: "lastTrimDate") as? Date
+        lastTrimSummary = defaults.string(forKey: "lastTrimSummary") ?? ""
+        trimNotifyOnComplete = defaults.bool(forKey: "trimNotifyOnComplete")
+        autoTrimEnabled = defaults.bool(forKey: "autoTrimEnabled")
+
+        if let raw = defaults.string(forKey: "autoTrimThresholdUnit"), let unit = TrimUnit(rawValue: raw) {
+            autoTrimThresholdUnit = unit
+        } else {
+            autoTrimThresholdUnit = .days
+        }
+        autoTrimThresholdValue = defaults.object(forKey: "autoTrimThresholdValue") as? Int ?? 90
+
+        autoTrimLastRun = defaults.object(forKey: "autoTrimLastRun") as? Date
+        autoTrimResult = defaults.string(forKey: "autoTrimResult") ?? ""
+
+        defaults.removeObject(forKey: "ageThresholdMonths")
+        defaults.removeObject(forKey: "autoTrimAgeMonths")
     }
 
     func recordTrim(date: Date, count: Int, space: String) {

--- a/TimeMachineTrimmer/Services/AutoTrimService.swift
+++ b/TimeMachineTrimmer/Services/AutoTrimService.swift
@@ -1,0 +1,146 @@
+import Foundation
+import UserNotifications
+
+@MainActor
+final class AutoTrimService {
+    static let shared = AutoTrimService()
+
+    private let service = TMUtilService()
+    private var timer: Timer?
+    private var isRunning = false
+    private var requestedNotifications = false
+
+    func start() {
+        if SettingsStore.shared.autoTrimEnabled {
+            Task { await runNow() }
+        }
+        scheduleNextRun()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func runNow() async {
+        guard !isRunning else {
+            DebugLogger.log("AutoTrim: already running, skipping")
+            return
+        }
+        isRunning = true
+        defer {
+            isRunning = false
+            scheduleNextRun()
+        }
+
+        let settings = SettingsStore.shared
+
+        if let lastTrim = settings.autoTrimLastRun,
+           Date().timeIntervalSince(lastTrim) < 24 * 3_600 {
+            settings.autoTrimLastRun = Date()
+            settings.autoTrimResult = "Skipped: less than 24 hours since last trim"
+            return
+        }
+
+        let toDelete = await findCandidates(settings: settings)
+        guard !toDelete.isEmpty else { return }
+
+        await deleteCandidates(toDelete, settings: settings)
+    }
+
+    private func findCandidates(settings: SettingsStore) async -> [TimeMachineBackup] {
+        DebugLogger.log("AutoTrim: starting scan")
+        let destinations = try? await service.getDestinations()
+        guard let mountPoint = destinations?.first?.mountPoint else {
+            settings.autoTrimLastRun = Date()
+            settings.autoTrimResult = "No backup destination found"
+            return []
+        }
+
+        let backups = (try? await service.listBackups(mountPoint: mountPoint)) ?? []
+        let cutoff = settings.autoTrimThresholdUnit.cutoffDate(byAdding: settings.autoTrimThresholdValue)
+        let toDelete = backups.filter { $0.date < cutoff }
+
+        if toDelete.isEmpty {
+            let label: String = {
+                let count = settings.autoTrimThresholdValue
+                return "No backups older than \(count) \(settings.autoTrimThresholdUnit.displayName(count: count))"
+            }()
+            settings.autoTrimLastRun = Date()
+            settings.autoTrimResult = label
+        }
+
+        DebugLogger.log("AutoTrim: found \(toDelete.count) candidate(s) out of \(backups.count)")
+        return toDelete
+    }
+
+    private func deleteCandidates(_ toDelete: [TimeMachineBackup], settings: SettingsStore) async {
+        DebugLogger.log("AutoTrim: deleting \(toDelete.count) backup(s)")
+        let client = HelperClient()
+        guard client.isInstalled else {
+            settings.autoTrimLastRun = Date()
+            settings.autoTrimResult = "Helper not installed"
+            return
+        }
+
+        do {
+            let results = try await client.deleteBackups(toDelete)
+            var deleted = 0
+            for backup in toDelete {
+                if let error = results[backup.id], !error.isEmpty {
+                    DebugLogger.log("AutoTrim: failed \(backup.snapshotName ?? backup.id) — \(error)")
+                } else {
+                    deleted += 1
+                }
+            }
+            SettingsStore.shared.recordTrim(date: Date(), count: deleted, space: "")
+            settings.autoTrimLastRun = Date()
+            settings.autoTrimResult = "\(deleted) snapshot(s) deleted"
+            DebugLogger.log("AutoTrim: done — \(deleted) deleted")
+
+            if settings.trimNotifyOnComplete {
+                postNotification(title: "Auto Trim Complete", body: "\(deleted) old backup(s) deleted.")
+            }
+        } catch {
+            DebugLogger.log("AutoTrim: deletion failed — \(error.localizedDescription)")
+            settings.autoTrimLastRun = Date()
+            settings.autoTrimResult = "Error: \(error.localizedDescription)"
+        }
+    }
+
+    private func scheduleNextRun() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 86_400, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard SettingsStore.shared.autoTrimEnabled else { return }
+                await self?.runNow()
+            }
+        }
+    }
+
+    private func postNotification(title: String, body: String) {
+        if !requestedNotifications {
+            let center = UNUserNotificationCenter.current()
+            center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                Task { @MainActor in
+                    self.requestedNotifications = true
+                    if granted { self.deliverNotification(title: title, body: body) }
+                }
+            }
+        } else {
+            deliverNotification(title: title, body: body)
+        }
+    }
+
+    private func deliverNotification(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/TimeMachineTrimmer/Services/HelperClient.swift
+++ b/TimeMachineTrimmer/Services/HelperClient.swift
@@ -25,7 +25,7 @@ actor HelperClient {
 
     // MARK: - Installation Check
 
-    var isInstalled: Bool {
+    nonisolated var isInstalled: Bool {
         FileManager.default.fileExists(atPath: helperBinary)
             && FileManager.default.fileExists(atPath: helperPlist)
     }
@@ -71,6 +71,38 @@ actor HelperClient {
                 throw TMUtilTypes.TMError.processFailed("Installation cancelled by user")
             }
             throw TMUtilTypes.TMError.processFailed("Helper installation failed: \(errMsg)")
+        }
+    }
+
+    // MARK: - Uninstall
+
+    nonisolated func uninstall() throws {
+        let script = """
+        launchctl bootout system "\(helperPlist)" 2>/dev/null || true
+        rm -f "\(helperBinary)" "\(helperPlist)"
+        """
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = [
+            "-e",
+            "do shell script \"\(script.replacingOccurrences(of: "\"", with: "\\\""))\" with administrator privileges"
+        ]
+
+        let errPipe = Pipe()
+        task.standardError = errPipe
+
+        try task.run()
+        task.waitUntilExit()
+
+        guard task.terminationStatus == 0 else {
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let errMsg = String(data: errData, encoding: .utf8) ?? "Unknown error"
+            if errMsg.localizedCaseInsensitiveContains("cancelled")
+                || errMsg.localizedCaseInsensitiveContains("(-128)") {
+                throw TMUtilTypes.TMError.processFailed("Uninstallation cancelled by user")
+            }
+            throw TMUtilTypes.TMError.processFailed("Helper uninstallation failed: \(errMsg)")
         }
     }
 

--- a/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
+++ b/TimeMachineTrimmer/ViewModels/BackupViewModel.swift
@@ -76,7 +76,10 @@ final class BackupViewModel {
     var selectedMethod: TrimMethod = .age {
         didSet { if selectedMethod == .age { updateAgeSelection() } }
     }
-    var ageThresholdMonths: Int = 6 {
+    var trimThresholdValue: Int = SettingsStore.shared.trimThresholdValue {
+        didSet { if selectedMethod == .age { updateAgeSelection() } }
+    }
+    var trimThresholdUnit: TrimUnit = SettingsStore.shared.trimThresholdUnit {
         didSet { if selectedMethod == .age { updateAgeSelection() } }
     }
     var previewBackups: [TimeMachineBackup] = []
@@ -215,11 +218,7 @@ final class BackupViewModel {
     }
 
     func updateAgeSelection() {
-        let cutoff = Calendar.current.date(
-            byAdding: .month,
-            value: -ageThresholdMonths,
-            to: Date()
-        ) ?? Date()
+        let cutoff = trimThresholdUnit.cutoffDate(byAdding: trimThresholdValue)
         selectedBackupIds = Set(backups.filter { $0.date < cutoff }.map(\.id))
     }
 
@@ -231,7 +230,7 @@ final class BackupViewModel {
 
         // Try helper batch first
         let helperClient = HelperClient()
-        if await helperClient.isInstalled {
+        if helperClient.isInstalled {
             isBatchDeletion = true
             deletionLog.append("Sending \(previewBackups.count) backup(s) to privileged helper...")
             do {
@@ -353,10 +352,52 @@ final class BackupViewModel {
         selectedBackupIds.removeAll()
     }
 
-    func quickTrimNow(thresholdMonths: Int) async -> DeletionResult? {
-        DebugLogger.log("quickTrimNow: threshold=\(thresholdMonths)")
+    func prepareTrimNow(value: Int, unit: TrimUnit) async -> Int? {
+        DebugLogger.log("prepareTrimNow: value=\(value) unit=\(unit.rawValue)")
         isTrimNowActive = true
-        ageThresholdMonths = thresholdMonths
+        trimThresholdValue = value
+        trimThresholdUnit = unit
+        selectedMethod = .age
+
+        if !TMFDAUtils.checkFDA() {
+            needsPermissionSheet = true
+            isTrimNowActive = false
+            return nil
+        }
+
+        await scanBackups()
+        guard state == .scanned else {
+            isTrimNowActive = false
+            return nil
+        }
+
+        updateAgeSelection()
+
+        guard !selectedBackupIds.isEmpty else {
+            DebugLogger.log("prepareTrimNow: no backups match threshold")
+            isTrimNowActive = false
+            return nil
+        }
+
+        previewBackups = backups.filter { selectedBackupIds.contains($0.id) }
+        return previewBackups.count
+    }
+
+    func confirmedTrimNow() async -> DeletionResult? {
+        guard !previewBackups.isEmpty else { return nil }
+        await executeDeletion()
+        guard case .done(let result) = state else {
+            isTrimNowActive = false
+            return nil
+        }
+        return result
+    }
+
+    func quickTrimNow(value: Int, unit: TrimUnit) async -> DeletionResult? {
+        DebugLogger.log("quickTrimNow: value=\(value) unit=\(unit.rawValue)")
+        isTrimNowActive = true
+        trimThresholdValue = value
+        trimThresholdUnit = unit
         selectedMethod = .age
 
         if !TMFDAUtils.checkFDA() {

--- a/TimeMachineTrimmer/Views/ContentView.swift
+++ b/TimeMachineTrimmer/Views/ContentView.swift
@@ -101,6 +101,9 @@ struct WindowSetup: NSViewRepresentable {
                 window.isReleasedWhenClosed = false
                 window.delegate = Self.closeDelegate
                 Self.mainWindow = window
+                if !SettingsStore.shared.showWindowOnLaunch {
+                    window.orderOut(nil)
+                }
             }
         }
         return view

--- a/TimeMachineTrimmer/Views/SettingsView.swift
+++ b/TimeMachineTrimmer/Views/SettingsView.swift
@@ -1,71 +1,210 @@
 import SwiftUI
 
+private enum SettingsTab: String, CaseIterable {
+    case trim = "Trim"
+    case autoTrim = "Auto Trim"
+    case helper = "Helper"
+    case general = "General"
+
+    var icon: String {
+        switch self {
+        case .trim: "scissors"
+        case .autoTrim: "clock.arrow.2.circlepath"
+        case .helper: "shield.lefthalf.filled"
+        case .general: "gearshape"
+        }
+    }
+}
+
 struct SettingsView: View {
-    @State private var settings = SettingsStore.shared
+    @Environment(\.dismiss) private var dismiss
+    @Bindable private var settings = SettingsStore.shared
     @State private var helperStatus: String = "Checking..."
     @State private var showClearConfirm = false
+    @State private var selectedTab: SettingsTab = .trim
 
-    private let formatter: ByteCountFormatter = {
-        let fmt = ByteCountFormatter()
-        fmt.countStyle = .file
-        return fmt
-    }()
+    private func clampedValue(_ value: Int, to unit: TrimUnit) -> Int {
+        min(max(value, 1), unit.maxValue)
+    }
 
     var body: some View {
-        TabView {
-            trimDefaultsTab
-                .tabItem { Label("Trim", systemImage: "scissors") }
-
-            helperTab
-                .tabItem { Label("Helper", systemImage: "shield.lefthalf.filled") }
-
-            generalTab
-                .tabItem { Label("General", systemImage: "gearshape") }
+        VStack(spacing: 0) {
+            topBar
+            segmentPicker
+            tabContent
         }
-        .frame(width: 480, height: 340)
+        .frame(width: 480, height: 460)
         .onAppear { checkHelper() }
+    }
+
+    private var topBar: some View {
+        HStack {
+            Text("Settings")
+                .font(.headline)
+            Spacer()
+            Button(
+                action: { dismiss() },
+                label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+            )
+            .buttonStyle(.plain)
+            .keyboardShortcut(.escape)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+    }
+
+    private var segmentPicker: some View {
+        Picker("", selection: $selectedTab) {
+            ForEach(SettingsTab.allCases, id: \.self) { tab in
+                Label(tab.rawValue, systemImage: tab.icon).tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 16)
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        ScrollView {
+            Group {
+                switch selectedTab {
+                case .trim: trimDefaultsTab
+                case .autoTrim: autoTrimTab
+                case .helper: helperTab
+                case .general: generalTab
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
     }
 
     // MARK: - Trim Defaults
 
     private var trimDefaultsTab: some View {
-        Form {
-            Section {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Text("Age threshold:")
-                        Spacer()
-                        Text("\(settings.ageThresholdMonths) months")
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
+        VStack(spacing: 20) {
+            VStack(alignment: .leading, spacing: 8) {
+                Picker("", selection: $settings.trimThresholdUnit) {
+                    ForEach(TrimUnit.allCases, id: \.self) { unit in
+                        Text(unit.rawValue).tag(unit)
                     }
-                    Slider(value: Binding(
-                        get: { Double(settings.ageThresholdMonths) },
-                        set: { settings.ageThresholdMonths = Int($0) }
-                    ), in: 1...24, step: 1)
-                    Text("\"Trim Now\" will delete snapshots older than this.")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
                 }
-                .padding(.vertical, 4)
-            } header: {
-                Label("Quick Trim Defaults", systemImage: "clock")
+                .pickerStyle(.segmented)
+
+                HStack(spacing: 8) {
+                    TextField("", value: $settings.trimThresholdValue, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 64)
+                        .id(settings.trimThresholdValue)
+                        .onSubmit {
+                            settings.trimThresholdValue = clampedValue(
+                                settings.trimThresholdValue, to: settings.trimThresholdUnit
+                            )
+                        }
+                    Stepper(
+                        "Value",
+                        value: $settings.trimThresholdValue,
+                        in: 1...settings.trimThresholdUnit.maxValue
+                    )
+                    .labelsHidden()
+                }
+                Text("\"Trim Now\" will delete snapshots older than this.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+            .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal, 20)
+
+            Toggle("Show notification when trim completes", isOn: $settings.trimNotifyOnComplete)
+                .padding(12)
+                .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+                .padding(.horizontal, 20)
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Auto Trim
+
+    private var autoTrimTab: some View {
+        VStack(spacing: 20) {
+            Toggle("Enable automatic trimming", isOn: $settings.autoTrimEnabled)
+                .padding(12)
+                .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+                .padding(.horizontal, 20)
+
+            if settings.autoTrimEnabled {
+                VStack(alignment: .leading, spacing: 8) {
+                    Picker("", selection: $settings.autoTrimThresholdUnit) {
+                        ForEach(TrimUnit.allCases, id: \.self) { unit in
+                            Text(unit.rawValue).tag(unit)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    HStack(spacing: 8) {
+                        TextField("", value: $settings.autoTrimThresholdValue, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 64)
+                            .id(settings.autoTrimThresholdValue)
+                            .onSubmit {
+                                settings.autoTrimThresholdValue = clampedValue(
+                                    settings.autoTrimThresholdValue, to: settings.autoTrimThresholdUnit
+                                )
+                            }
+                        Stepper(
+                            "Value",
+                            value: $settings.autoTrimThresholdValue,
+                            in: 1...settings.autoTrimThresholdUnit.maxValue
+                        )
+                        .labelsHidden()
+                    }
+                }
+                .padding(12)
+                .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+                .padding(.horizontal, 20)
             }
 
-            Section {
-                Toggle("Show notification when trim completes", isOn: $settings.trimNotifyOnComplete)
-            } header: {
-                Label("Notifications", systemImage: "bell")
+            VStack(alignment: .leading, spacing: 6) {
+                if let date = settings.autoTrimLastRun {
+                    HStack {
+                        Text("Last run:")
+                        Spacer()
+                        Text(date.formatted(date: .long, time: .shortened))
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack {
+                        Text("Result:")
+                        Spacer()
+                        Text(settings.autoTrimResult)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text("Not yet run.")
+                        .foregroundStyle(.secondary)
+                }
+                Divider()
+                Button("Run Now") {
+                    Task { await AutoTrimService.shared.runNow() }
+                }
+                .disabled(!settings.autoTrimEnabled)
             }
+            .padding(12)
+            .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal, 20)
         }
-        .formStyle(.grouped)
+        .padding(.vertical, 4)
     }
 
     // MARK: - Helper
 
     private var helperTab: some View {
-        Form {
-            Section {
+        VStack(spacing: 20) {
+            VStack(alignment: .leading, spacing: 10) {
                 HStack {
                     Text("Status:")
                     Text(helperStatus)
@@ -81,31 +220,30 @@ struct SettingsView: View {
                         installHelper()
                     }
                 }
-            } header: {
-                Label("Privileged Helper", systemImage: "shield.lefthalf.filled")
-            }
 
-            Section {
                 Text("The helper runs as root and performs backup deletion. "
                      + "It is installed via an admin-privileged script.")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(3)
             }
+            .padding(12)
+            .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal, 20)
         }
-        .formStyle(.grouped)
+        .padding(.vertical, 4)
     }
 
     // MARK: - General
 
     private var generalTab: some View {
-        Form {
-            Section {
-                Toggle("Show main window on launch", isOn: $settings.showWindowOnLaunch)
-            } header: {
-                Label("Launch Behavior", systemImage: "power")
-            }
+        VStack(spacing: 20) {
+            Toggle("Show main window on launch", isOn: $settings.showWindowOnLaunch)
+                .padding(12)
+                .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+                .padding(.horizontal, 20)
 
-            Section {
+            VStack(alignment: .leading, spacing: 6) {
                 if let date = settings.lastTrimDate {
                     HStack {
                         Text("Last trim:")
@@ -119,6 +257,7 @@ struct SettingsView: View {
                         Text(settings.lastTrimSummary)
                             .foregroundStyle(.secondary)
                     }
+                    Divider()
                     Button("Clear History", role: .destructive) {
                         showClearConfirm = true
                     }
@@ -135,11 +274,12 @@ struct SettingsView: View {
                     Text("No trim history recorded yet.")
                         .foregroundStyle(.secondary)
                 }
-            } header: {
-                Label("Trim History", systemImage: "clock.arrow.circlepath")
             }
+            .padding(12)
+            .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal, 20)
         }
-        .formStyle(.grouped)
+        .padding(.vertical, 4)
     }
 
     // MARK: - Helper Actions
@@ -147,46 +287,31 @@ struct SettingsView: View {
     private func checkHelper() {
         Task {
             let client = HelperClient()
-            helperStatus = await client.isInstalled ? "Installed" : "Not installed"
+            helperStatus = client.isInstalled ? "Installed" : "Not installed"
         }
     }
 
     private func installHelper() {
-        let scriptPath = ".scripts/install_helper.sh"
-        let fullPath = (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent(scriptPath)
-        guard FileManager.default.fileExists(atPath: fullPath) else {
-            helperStatus = "Script not found: \(scriptPath)"
-            return
+        Task {
+            let client = HelperClient()
+            do {
+                try await client.ensureInstalled()
+                helperStatus = "Installed"
+            } catch {
+                helperStatus = "Install failed: \(error.localizedDescription)"
+            }
         }
-        let process = Process()
-        process.launchPath = "/bin/bash"
-        process.arguments = [fullPath]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        process.launch()
-        process.waitUntilExit()
-        helperStatus = process.terminationStatus == 0 ? "Installed" : "Install failed"
     }
 
     private func uninstallHelper() {
-        let scriptPath = ".scripts/uninstall_helper.sh"
-        let fullPath = (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent(scriptPath)
-        if FileManager.default.fileExists(atPath: fullPath) {
-            let process = Process()
-            process.launchPath = "/bin/bash"
-            process.arguments = [fullPath]
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
-            process.launch()
-            process.waitUntilExit()
-            helperStatus = process.terminationStatus == 0 ? "Not installed" : "Uninstall failed"
-        } else {
-            // Fallback via osascript
-            // swiftlint:disable:next line_length
-            let script = "do shell script \"launchctl unload /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist; rm -f /usr/local/bin/TimeMachineTrimmer-helper /Library/LaunchDaemons/com.ricardoleal.TimeMachineTrimmer.helper.plist\" with administrator privileges"
-            var error: NSDictionary?
-            NSAppleScript(source: script)?.executeAndReturnError(&error)
-            helperStatus = "Not installed"
+        Task {
+            let client = HelperClient()
+            do {
+                try client.uninstall()
+                helperStatus = "Not installed"
+            } catch {
+                helperStatus = "Uninstall failed: \(error.localizedDescription)"
+            }
         }
     }
 }

--- a/TimeMachineTrimmer/Views/TrimByAgeView.swift
+++ b/TimeMachineTrimmer/Views/TrimByAgeView.swift
@@ -3,34 +3,58 @@ import SwiftUI
 struct TrimByAgeView: View {
     @Environment(BackupViewModel.self) private var viewModel
 
+    private var display: String {
+        let value = viewModel.trimThresholdValue
+        let unit = viewModel.trimThresholdUnit
+        return "\(value) \(unit.displayName(count: value))"
+    }
+
+    private var maxLabel: String {
+        let unit = viewModel.trimThresholdUnit
+        return "\(unit.maxValue) \(unit.displayName(count: unit.maxValue))"
+    }
+
     var body: some View {
         VStack(spacing: 6) {
             HStack {
                 Text("Delete backups older than")
                     .font(.callout)
-                Text("\(viewModel.ageThresholdMonths) months")
+                Text(display)
                     .font(.callout.weight(.semibold))
                     .monospacedDigit()
                     .contentTransition(.numericText())
                 Spacer()
             }
 
+            Picker("Unit", selection: Binding(
+                get: { viewModel.trimThresholdUnit },
+                set: { newUnit in
+                    viewModel.trimThresholdUnit = newUnit
+                    viewModel.trimThresholdValue = min(viewModel.trimThresholdValue, newUnit.maxValue)
+                }
+            )) {
+                ForEach(TrimUnit.allCases, id: \.self) { unit in
+                    Text(unit.rawValue).tag(unit)
+                }
+            }
+            .pickerStyle(.segmented)
+
             Slider(
                 value: Binding(
-                    get: { Double(viewModel.ageThresholdMonths) },
-                    set: { viewModel.ageThresholdMonths = Int($0) }
+                    get: { Double(viewModel.trimThresholdValue) },
+                    set: { viewModel.trimThresholdValue = Int($0) }
                 ),
-                in: 1...24,
+                in: 1...Double(viewModel.trimThresholdUnit.maxValue),
                 step: 1
             )
             .padding(.horizontal, 2)
 
             HStack {
-                Text("1 month")
+                Text("1 \(viewModel.trimThresholdUnit.displayName(count: 1))")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                 Spacer()
-                Text("24 months")
+                Text(maxLabel)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }

--- a/TimeMachineTrimmer/Views/TrimNowSheet.swift
+++ b/TimeMachineTrimmer/Views/TrimNowSheet.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 private enum TrimPhase {
     case configure
-    case running
+    case scanning
+    case preview(count: Int)
+    case deleting
     case done(BackupViewModel.DeletionResult)
 }
 
@@ -10,90 +12,189 @@ struct TrimNowSheet: View {
     @Environment(BackupViewModel.self) private var viewModel
     @Environment(\.dismiss) private var dismiss
     @State private var phase: TrimPhase = .configure
-    @State private var threshold: Int = SettingsStore.shared.ageThresholdMonths
+    @State private var thresholdValue: Int = SettingsStore.shared.trimThresholdValue
+    @State private var thresholdUnit: TrimUnit = SettingsStore.shared.trimThresholdUnit
     @State private var progressText: String = ""
 
     private let formatter = ByteCountFormatter()
 
     private var isRunning: Bool {
-        if case .running = phase { true } else { false }
+        if case .scanning = phase { true } else if case .deleting = phase { true } else { false }
+    }
+
+    private var previewCount: Int {
+        if case .preview(let count) = phase { count } else { 0 }
     }
 
     var body: some View {
-        VStack(spacing: 20) {
-            switch phase {
-            case .configure:
-                configureView
-            case .running:
-                runningView
-            case .done(let result):
-                doneView(result)
+        VStack(spacing: 0) {
+            topBar
+
+            Group {
+                switch phase {
+                case .configure:
+                    configureView
+                case .scanning:
+                    scanningView
+                case .preview:
+                    previewView
+                case .deleting:
+                    deletingView
+                case .done(let result):
+                    doneView(result)
+                }
             }
         }
         .frame(width: 380)
-        .padding(24)
         .interactiveDismissDisabled(isRunning)
         .onDisappear {
             viewModel.isTrimNowActive = false
         }
     }
 
+    private var topBar: some View {
+        HStack {
+            Text("Trim Backups")
+                .font(.headline)
+            Spacer()
+            Button(
+                action: { dismiss() },
+                label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+            )
+            .buttonStyle(.plain)
+            .disabled(isRunning)
+            .keyboardShortcut(.escape)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+    }
+
     // MARK: - Configure
 
     private var configureView: some View {
-        VStack(spacing: 20) {
+        VStack(spacing: 24) {
             Image(systemName: "clock.arrow.circlepath")
-                .font(.title)
-                .foregroundStyle(.secondary)
+                .font(.system(size: 36))
+                .foregroundStyle(.tint)
+                .padding(.top, 8)
 
-            Text("Trim Backups")
-                .font(.headline)
-
-            Text("Delete snapshots older than \(threshold) months")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 12) {
-                Text("1")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                Slider(value: Binding(
-                    get: { Double(threshold) },
-                    set: { threshold = Int($0) }
-                ), in: 1...24, step: 1)
-                Text("24")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+            VStack(spacing: 4) {
+                Text("Delete snapshots older than")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("\(thresholdValue) \(thresholdUnit.displayName(count: thresholdValue))")
+                    .font(.title)
+                    .fontWeight(.medium)
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .padding(.vertical, 4)
             }
 
-            Text("\(threshold) months")
-                .font(.title3)
-                .fontWeight(.medium)
-                .monospacedDigit()
-                .contentTransition(.numericText())
+            VStack(spacing: 8) {
+                Picker("", selection: $thresholdUnit) {
+                    ForEach(TrimUnit.allCases, id: \.self) { unit in
+                        Text(unit.rawValue).tag(unit)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: thresholdUnit) { _, newUnit in
+                    thresholdValue = min(thresholdValue, newUnit.maxValue)
+                }
+
+                HStack(spacing: 8) {
+                    TextField("", value: $thresholdValue, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 64)
+                        .onSubmit {
+                            thresholdValue = min(max(thresholdValue, 1), thresholdUnit.maxValue)
+                        }
+                    Stepper("Value", value: $thresholdValue, in: 1...thresholdUnit.maxValue)
+                        .labelsHidden()
+                    Text(thresholdUnit.displayName(count: thresholdValue))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 4)
+            }
 
             HStack(spacing: 12) {
                 Button("Cancel", role: .cancel) { dismiss() }
                     .keyboardShortcut(.escape)
 
-                Button("Trim") {
-                    startTrim()
+                Button("Continue") {
+                    startScan()
                 }
                 .keyboardShortcut(.return)
                 .buttonStyle(.borderedProminent)
             }
             .padding(.top, 8)
         }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 24)
     }
 
-    // MARK: - Running
+    // MARK: - Scanning
 
-    private var runningView: some View {
+    private var scanningView: some View {
         VStack(spacing: 24) {
             ProgressView()
                 .scaleEffect(1.2)
+                .padding(.top, 20)
 
-            Text("Trimming backups...")
+            Text("Scanning backups...")
+                .font(.headline)
+        }
+        .frame(maxHeight: .infinity)
+        .padding(24)
+    }
+
+    // MARK: - Preview
+
+    private var previewView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "trash")
+                .font(.system(size: 36))
+                .foregroundStyle(.tint)
+                .padding(.top, 8)
+
+            VStack(spacing: 4) {
+                Text("\(previewCount) backup(s) will be deleted")
+                    .font(.title3)
+                    .fontWeight(.medium)
+                Text("Backups older than \(thresholdValue) \(thresholdUnit.displayName(count: thresholdValue))")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 12) {
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .keyboardShortcut(.escape)
+
+                Button("Delete \(previewCount)") {
+                    startDelete()
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+            }
+            .padding(.top, 8)
+        }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 24)
+    }
+
+    // MARK: - Deleting
+
+    private var deletingView: some View {
+        VStack(spacing: 24) {
+            ProgressView()
+                .scaleEffect(1.2)
+                .padding(.top, 20)
+
+            Text("Deleting backups...")
                 .font(.headline)
 
             if !progressText.isEmpty {
@@ -103,23 +204,26 @@ struct TrimNowSheet: View {
                     .multilineTextAlignment(.center)
             }
         }
+        .frame(maxHeight: .infinity)
+        .padding(24)
     }
 
     // MARK: - Done
 
     private func doneView(_ result: BackupViewModel.DeletionResult) -> some View {
-        VStack(spacing: 20) {
+        VStack(spacing: 24) {
             Image(systemName: result.failed > 0 ? "exclamationmark.triangle" : "checkmark.circle.fill")
-                .font(.system(size: 36))
+                .font(.system(size: 40))
                 .foregroundStyle(result.failed > 0 ? .orange : .green)
+                .padding(.top, 12)
 
             Text(result.failed > 0 ? "Trim completed with errors" : "Trim completed")
                 .font(.headline)
 
-            HStack(spacing: 24) {
-                VStack {
+            HStack(spacing: 32) {
+                VStack(spacing: 2) {
                     Text("\(result.deleted)")
-                        .font(.title2)
+                        .font(.title)
                         .fontWeight(.semibold)
                     Text("Deleted")
                         .font(.caption)
@@ -127,9 +231,9 @@ struct TrimNowSheet: View {
                 }
 
                 if result.failed > 0 {
-                    VStack {
+                    VStack(spacing: 2) {
                         Text("\(result.failed)")
-                            .font(.title2)
+                            .font(.title)
                             .fontWeight(.semibold)
                             .foregroundStyle(.orange)
                         Text("Failed")
@@ -145,18 +249,34 @@ struct TrimNowSheet: View {
                 dismiss()
             }
             .keyboardShortcut(.return)
-            .padding(.top, 4)
         }
+        .padding(24)
     }
 
     // MARK: - Actions
 
-    private func startTrim() {
-        phase = .running
-        progressText = "Scanning backups..."
+    private func startScan() {
+        phase = .scanning
 
         Task {
-            let result = await viewModel.quickTrimNow(thresholdMonths: threshold)
+            let count = await viewModel.prepareTrimNow(value: thresholdValue, unit: thresholdUnit)
+            await MainActor.run {
+                if let count, count > 0 {
+                    phase = .preview(count: count)
+                } else {
+                    viewModel.reset()
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    private func startDelete() {
+        phase = .deleting
+        progressText = "Deleting backups..."
+
+        Task {
+            let result = await viewModel.confirmedTrimNow()
             await MainActor.run {
                 if let result {
                     if result.deleted > 0 || result.failed > 0 {
@@ -168,11 +288,8 @@ struct TrimNowSheet: View {
                     }
                     phase = .done(result)
                 } else {
-                    progressText = "No backups to trim"
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                        viewModel.reset()
-                        dismiss()
-                    }
+                    viewModel.reset()
+                    dismiss()
                 }
             }
         }


### PR DESCRIPTION
## Description
Completes the auto-trim feature with daily schedule, adds a preview phase to TrimNow, rewrites Settings with a native macOS segmented tab layout, and fixes the window launch visibility bug.

- **AutoTrimService** — new service with daily timer (86400s), immediate eligibility check on start, Run Now bypasses toggle, cooldown uses `autoTrimLastRun`
- **TrimUnit** — extracted enum (days/weeks/months) with `cutoffDate(byAdding:to:)` and `displayName(count:)`
- **SettingsStore** — all 11 props converted from `@ObservationIgnored`+computed to stored var+`didSet` for proper `@Observable` tracking
- **SettingsView** — replaced `TabView` with custom segmented picker (Trim/Auto Trim/Helper/General tabs), card-based layout, removed all section header Labels and Picker "Unit" labels
- **TrimNowSheet** — `configure → scanning → preview → deleting → done` flow, user sees backup count before confirming deletion
- **WindowSetup** — `orderOut(nil)` when `showWindowOnLaunch = false` (fix: SwiftUI creates window before AppDelegate fires)
- **BackupViewModel** — `prepareTrimNow()` / `confirmedTrimNow()` split for preview flow; `trimThresholdValue/Unit` replaces `ageThresholdMonths`
- **HelperClient** — `nonisolated isInstalled` + `uninstall()` via `osascript` with admin privileges
- **TrimByAgeView** — unit picker, dynamic slider bounds per selected unit

## Related Issue
#6 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix
- [X] New feature
- [X] Enhancement/improvement
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
```shell
==> Compiling test sources...

==> Running tests...
TimeMachineTrimmer Tests
================================================

## ResumptionFlag
  ✓ first call returns true
  ✓ second call returns false
  ✓ third call returns false
  ✓ only one succeeds from 100 concurrent calls

## Date Part Extraction
  ✓ full TM snapshot name
  ✓ non-TM string unchanged
  ✓ empty date part

## Backup Dict Validation
  ✓ valid dict returns nil
  ✓ empty snapshot returns error
  ✓ error mentions snapshotName
  ✓ empty volume returns error
  ✓ error mentions volumePath
  ✓ empty dict returns error

## HelperClient Backup Dict
  ✓ dict contains key 'id'
  ✓ dict contains key 'volumePath'
  ✓ dict contains key 'path'
  ✓ dict contains key 'snapshotName'
  ✓ Optional("my-id") == Optional("my-id")
  ✓ Optional("/path with/spaces") == Optional("/path with/spaces")
  ✓ Optional("snap") == Optional("snap")
  ✓ Optional("/Volumes/My Disk") == Optional("/Volumes/My Disk")
  ✓ empty id ok
  ✓ 4 keys even with empty values

## XPC Reply Format
  ✓ empty string means success
  ✓ non-empty string means error
  ✓ success = empty
  ✓ failure = error message


================================================
Integration Tests
================================================

-- Build verification --
  ✓ binary is Mach-O format
  ✓ binary is arm64 architecture
  ✓ code signature present

-- XPC communication --
  ✓ ping: helper is alive
  ✓ version: XPC response received

-- Delete operations --
  ✓ delete: returned (no hang)
  ✓ delete: produced a result line
  ✓ delete (bad volume): returned (no hang)

──────────────────────────────
35 passed, 0 failed
──────────────────────────────
```
## Checklist
- [ ] My code follows the existing code style
- [x] I've tested the changes on macOS 26 (Tahoe)
- [ ] I've updated the README if necessary
- [x] I've added comments for complex logic
- [ ] My changes don't break existing functionality

## Screenshots (if applicable)
<img width="1072" height="664" alt="image" src="https://github.com/user-attachments/assets/80c0ca30-4986-4ece-9e56-fb869ce91b2d" />
## Additional Notes
<!-- Any other information reviewers should know? -->
